### PR TITLE
fix submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake"]
 	path = cmake
-	url = git://github.com/jrl-umi3218/jrl-cmakemodules.git
+	url = https://github.com/jrl-umi3218/jrl-cmakemodules.git


### PR DESCRIPTION
fix:

https://gitlab.laas.fr/gsaurel/hpp-doc/-/jobs/253110

```
fatal: unable to connect to github.com:
github.com[0: 140.82.121.4]: errno=Connection timed out
fatal: clone of 'git://github.com/jrl-umi3218/jrl-cmakemodules.git' into submodule path '/workspace/src/hpp-python/cmake' failed
Failed to clone 'cmake'. Retry scheduled
fatal: unable to connect to github.com:
github.com[0: 140.82.121.4]: errno=Connection timed out
fatal: clone of 'git://github.com/jrl-umi3218/jrl-cmakemodules.git' into submodule path '/workspace/src/hpp-python/cmake' failed
Failed to clone 'cmake' a second time, aborting