### PR TITLE
Boost placeholders

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,35 @@
 ci:
-    autoupdate_branch: 'devel'
+  autoupdate_branch: devel
 repos:
--   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.5
-    hooks:
-    -   id: clang-format
-        args: [--style=Google]
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
-    -   id: check-added-large-files
-    -   id: check-ast
-    -   id: check-executables-have-shebangs
-    -   id: check-json
-    -   id: check-merge-conflict
-    -   id: check-symlinks
-    -   id: check-toml
-    -   id: check-yaml
-    -   id: debug-statements
-    -   id: destroyed-symlinks
-    -   id: detect-private-key
-    -   id: end-of-file-fixer
-    -   id: fix-byte-order-marker
-    -   id: mixed-line-ending
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-    -   id: black
--   repo: https://github.com/cheshirekow/cmake-format-precommit
-    rev: v0.6.13
-    hooks:
-    - id: cmake-format
+- repo: https://github.com/cheshirekow/cmake-format-precommit
+  rev: v0.6.13
+  hooks:
+  - id: cmake-format
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v18.1.5
+  hooks:
+  - id: clang-format
+    args:
+    - --style=Google
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+  - id: check-added-large-files
+  - id: check-ast
+  - id: check-executables-have-shebangs
+  - id: check-json
+  - id: check-merge-conflict
+  - id: check-symlinks
+  - id: check-toml
+  - id: check-yaml
+  - id: debug-statements
+  - id: destroyed-symlinks
+  - id: detect-private-key
+  - id: end-of-file-fixer
+  - id: fix-byte-order-marker
+  - id: mixed-line-ending
+  - id: trailing-whitespace
+- repo: https://github.com/psf/black
+  rev: 24.4.2
+  hooks:
+  - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   hooks:
   - id: cmake-format
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v18.1.5
+  rev: v18.1.7
   hooks:
   - id: clang-format
     args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,6 @@ repos:
     rev: 24.4.2
     hooks:
     -   id: black
--   repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-    -   id: flake8
 -   repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
     hooks:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,41 @@ set(PROJECT_URL "")
 set(CXX_DISABLE_WERROR TRUE)
 set(PROJECT_USE_CMAKE_EXPORT TRUE)
 
-include(cmake/base.cmake)
-include(cmake/python.cmake)
-include(cmake/boost.cmake)
-include(cmake/test.cmake)
+# Check if the submodule cmake have been initialized
+set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake")
+if(EXISTS "${JRL_CMAKE_MODULES}/base.cmake")
+  message(STATUS "JRL cmakemodules found in 'cmake/' git submodule")
+else()
+  find_package(jrl-cmakemodules QUIET CONFIG)
+  if(jrl-cmakemodules_FOUND)
+    get_property(
+      JRL_CMAKE_MODULES
+      TARGET jrl-cmakemodules::jrl-cmakemodules
+      PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+    message(STATUS "JRL cmakemodules found on system at ${JRL_CMAKE_MODULES}")
+  elseif(${CMAKE_VERSION} VERSION_LESS "3.14.0")
+    message(
+      FATAL_ERROR
+        "\nCan't find jrl-cmakemodules. Please either:\n"
+        "  - use git submodule: 'git submodule update --init'\n"
+        "  - or install https://github.com/jrl-umi3218/jrl-cmakemodules\n"
+        "  - or upgrade your CMake version to >= 3.14 to allow automatic fetching\n"
+    )
+  else()
+    message(STATUS "JRL cmakemodules not found. Let's fetch it.")
+    include(FetchContent)
+    FetchContent_Declare(
+      "jrl-cmakemodules"
+      GIT_REPOSITORY "https://github.com/jrl-umi3218/jrl-cmakemodules.git")
+    FetchContent_MakeAvailable("jrl-cmakemodules")
+    FetchContent_GetProperties("jrl-cmakemodules" SOURCE_DIR JRL_CMAKE_MODULES)
+  endif()
+endif()
+
+include("${JRL_CMAKE_MODULES}/base.cmake")
+include("${JRL_CMAKE_MODULES}/python.cmake")
+include("${JRL_CMAKE_MODULES}/boost.cmake")
+include("${JRL_CMAKE_MODULES}/test.cmake")
 
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)
 project(${PROJECT_NAME} ${PROJECT_ARGS})

--- a/src/pyhpp/core/problem-solver.cc
+++ b/src/pyhpp/core/problem-solver.cc
@@ -86,7 +86,8 @@ struct Builder {
                                const std::string& key, PyObject* callable) {
     // TODO check if incref is needed
     // incref (callable);
-    c.add(key, T(boost::bind(&Builder<Type>::call2, callable, boost::placeholders::_1)));
+    c.add(key, T(boost::bind(&Builder<Type>::call2, callable,
+                             boost::placeholders::_1)));
   }
 
   PyObject* callable;

--- a/src/pyhpp/core/problem-solver.cc
+++ b/src/pyhpp/core/problem-solver.cc
@@ -86,7 +86,7 @@ struct Builder {
                                const std::string& key, PyObject* callable) {
     // TODO check if incref is needed
     // incref (callable);
-    c.add(key, T(boost::bind(&Builder<Type>::call2, callable, _1)));
+    c.add(key, T(boost::bind(&Builder<Type>::call2, callable, boost::placeholders::_1)));
   }
 
   PyObject* callable;


### PR DESCRIPTION
Hi,

This fix boost placeholders on 24.04 and arch:
```cpp
/workspace/src/hpp-python/build-rel/src/pyhpp/core/problem-solver.cc: In static member function 'static void pyhpp::core::Builder<Type, TypePtr_t>::add_to_container(hpp::core::Container<T>&, const std::string&, PyObject*)':
/workspace/src/hpp-python/build-rel/src/pyhpp/core/problem-solver.cc:89:63: error: '_1' was not declared in this scope
   89 |     c.add(key, T(boost::bind(&Builder<Type>::call2, callable, _1)));
      |                                                               ^~
/workspace/src/hpp-python/build-rel/src/pyhpp/core/problem-solver.cc:89:63: note: suggested alternatives:
In file included from /usr/include/boost/mpl/aux_/include_preprocessed.hpp:37,
                 from /usr/include/boost/mpl/placeholders.hpp:43,
                 from /usr/include/boost/mpl/apply.hpp:24,
                 from /usr/include/boost/python/object/pointer_holder.hpp:28,
                 from /usr/include/boost/python/to_python_indirect.hpp:10,
                 from /usr/include/boost/python/converter/arg_to_python.hpp:10,
                 from /usr/include/boost/python/call.hpp:15,
                 from /usr/include/boost/python/object_core.hpp:14,
                 from /usr/include/boost/python/args.hpp:22,
                 from /usr/include/boost/python.hpp:11,
                 from /workspace/src/hpp-python/build-rel/src/pyhpp/core/problem-solver.cc:20:
/usr/include/boost/mpl/aux_/preprocessed/gcc/placeholders.hpp:29:16: note:   'mpl_::_1'
   29 | typedef arg<1> _1;
      |                ^~
In file included from /usr/include/boost/config/no_tr1/functional.hpp:21,
                 from /usr/include/boost/function/detail/prologue.hpp:15,
                 from /usr/include/boost/function/function_template.hpp:13,
                 from /usr/include/boost/function/detail/maybe_include.hpp:15,
                 from /usr/include/boost/function/function0.hpp:11,
                 from /usr/include/boost/python/errors.hpp:13,
                 from /usr/include/boost/python/handle.hpp:11,
                 from /usr/include/boost/python/args_fwd.hpp:10,
                 from /usr/include/boost/python/args.hpp:10:
/usr/include/c++/13/functional:294:48: note:   'std::placeholders::_1'
  294 |     _GLIBCXX_PLACEHOLDER const _Placeholder<1> _1;
      |                                                ^~
/usr/include/boost/mpl/aux_/preprocessed/gcc/placeholders.hpp:29:16: note:   'mpl_::_1'
   29 | typedef arg<1> _1;
      |                ^~
In file included from /usr/include/boost/bind/bind.hpp:2337,
                 from /usr/include/boost/python/exception_translator.hpp:10,
                 from /usr/include/boost/python.hpp:28:
/usr/include/boost/bind/placeholders.hpp:46:38: note:   'boost::placeholders::_1'
   46 | BOOST_INLINE_CONSTEXPR boost::arg<1> _1;
      |                                      ^~
/usr/include/boost/mpl/aux_/preprocessed/gcc/placeholders.hpp:29:16: note:   'mpl_::_1'
   29 | typedef arg<1> _1;
   ```

While here, update CMake to  allow use of installed jrl-cmakemodules