### PR TITLE
Add constraint graph factory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,11 @@ add_project_dependency(hpp-corbaserver REQUIRED)
 add_project_dependency(hpp-manipulation REQUIRED)
 add_project_dependency(hpp-manipulation-urdf REQUIRED)
 
+if(BUILD_TESTING)
+  add_project_dependency(hpp-environments REQUIRED)
+  add_project_dependency(hpp_tutorial REQUIRED)
+endif()
+
 add_library(${PROJECT_NAME} INTERFACE)
 install(
   TARGETS ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,6 @@ add_project_dependency(hpp-manipulation-urdf REQUIRED)
 
 if(BUILD_TESTING)
   add_project_dependency(hpp-environments REQUIRED)
-  add_project_dependency(hpp_tutorial REQUIRED)
 endif()
 
 add_library(${PROJECT_NAME} INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ add_project_dependency(hpp-manipulation REQUIRED)
 add_project_dependency(hpp-manipulation-urdf REQUIRED)
 
 if(BUILD_TESTING)
-  add_project_dependency(hpp-environments REQUIRED)
+  find_package(hpp-environments REQUIRED)
 endif()
 
 add_library(${PROJECT_NAME} INTERFACE)

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,13 @@
                 pkgs.hpp-manipulation
                 pkgs.hpp-manipulation-urdf
               ];
+              installCheckInputs = super.installCheckInputs ++ [
+                pkgs.hpp-environments
+              ];
+              preInstallCheck = ''
+                export ROS_PACKAGE_PATH=${pkgs.example-robot-data}/share:${pkgs.hpp-environments}/share
+                make test
+              '';
               src = lib.fileset.toSource {
                 root = ./.;
                 fileset = lib.fileset.unions [

--- a/include/pyhpp/constraints/fwd.hh
+++ b/include/pyhpp/constraints/fwd.hh
@@ -39,6 +39,7 @@ void exposeGenericTransformations();
 void exposeImplicit();
 void exposeExplicitConstraintSet();
 void exposeExplicit();
+void exposeLockedJoint();
 void exposeHierarchicalIterativeSolver();
 void exposeBySubstitution();
 }  // namespace constraints

--- a/include/pyhpp/core/path-planner.hh
+++ b/include/pyhpp/core/path-planner.hh
@@ -33,7 +33,6 @@
 #include <hpp/core/path-vector.hh>
 #include <hpp/core/problem.hh>
 #include <hpp/core/roadmap.hh>
-
 #include <pyhpp/core/problem.hh>
 
 namespace pyhpp {

--- a/include/pyhpp/core/path-planner.hh
+++ b/include/pyhpp/core/path-planner.hh
@@ -34,7 +34,7 @@
 #include <hpp/core/problem.hh>
 #include <hpp/core/roadmap.hh>
 
-#include "pyhpp/core/problem.hh"
+#include <pyhpp/core/problem.hh>
 
 namespace pyhpp {
 namespace core {

--- a/include/pyhpp/core/problem.hh
+++ b/include/pyhpp/core/problem.hh
@@ -63,7 +63,6 @@ typedef hpp::core::DistancePtr_t DistancePtr_t;
 struct Problem {
   hpp::core::ProblemPtr_t obj;
 
-  Problem(const hpp::core::ProblemPtr_t& object);
   Problem(const DevicePtr_t& robot);
 
   // wrapped methods

--- a/include/pyhpp/manipulation/fwd.hh
+++ b/include/pyhpp/manipulation/fwd.hh
@@ -34,8 +34,21 @@
 
 namespace pyhpp {
 namespace manipulation {
+
+struct Device;
+struct Problem;
+struct PyWGraph;
+
+// Shared pointer typedefs
+typedef std::shared_ptr<Device> PyWDevicePtr_t;
+typedef std::shared_ptr<Problem> PyWProblemPtr_t;
+typedef std::shared_ptr<PyWGraph> PyWGraphPtr_t;
+
 void exposeDevice();
 void exposeHandle();
+void exposeGraph();
+void exposeProblem();
+
 }  // namespace manipulation
 }  // namespace pyhpp
 

--- a/include/pyhpp/util.hh
+++ b/include/pyhpp/util.hh
@@ -60,7 +60,8 @@
 #define PYHPP_DEFINE_GETTER_SETTER_CONST_REF(CLASS, METHOD, TYPE)    \
   def(#METHOD, static_cast<TYPE (CLASS::*)() const>(&CLASS::METHOD)) \
       .def(#METHOD, static_cast<void (CLASS::*)(const TYPE&)>(&CLASS::METHOD))
-#define PYHPP_DEFINE_METHOD_STATIC(CLASS, METHOD) def(#METHOD, &CLASS::METHOD).staticmethod(#METHOD)
+#define PYHPP_DEFINE_METHOD_STATIC(CLASS, METHOD) \
+  def(#METHOD, &CLASS::METHOD).staticmethod(#METHOD)
 
 namespace pyhpp {
 template <typename ObjectWithPrintMethod>
@@ -86,20 +87,18 @@ struct VectorOfPtr {
   }
 };
 
-template<typename T>
+template <typename T>
 std::vector<T> extract_vector(boost::python::list py_list) {
-    return std::vector<T>(
-        boost::python::stl_input_iterator<T>(py_list),
-        boost::python::stl_input_iterator<T>()
-    );
+  return std::vector<T>(boost::python::stl_input_iterator<T>(py_list),
+                        boost::python::stl_input_iterator<T>());
 }
-template<typename T>
+template <typename T>
 boost::python::list to_python_list(const std::vector<T>& vec) {
-    boost::python::list py_list;
-    for (const auto& item : vec) {
-        py_list.append(item);
-    }
-    return py_list;
+  boost::python::list py_list;
+  for (const auto& item : vec) {
+    py_list.append(item);
+  }
+  return py_list;
 }
 
 }  // namespace pyhpp

--- a/include/pyhpp/util.hh
+++ b/include/pyhpp/util.hh
@@ -60,6 +60,7 @@
 #define PYHPP_DEFINE_GETTER_SETTER_CONST_REF(CLASS, METHOD, TYPE)    \
   def(#METHOD, static_cast<TYPE (CLASS::*)() const>(&CLASS::METHOD)) \
       .def(#METHOD, static_cast<void (CLASS::*)(const TYPE&)>(&CLASS::METHOD))
+#define PYHPP_DEFINE_METHOD_STATIC(CLASS, METHOD) def(#METHOD, &CLASS::METHOD).staticmethod(#METHOD)
 
 namespace pyhpp {
 template <typename ObjectWithPrintMethod>
@@ -84,6 +85,23 @@ struct VectorOfPtr {
     return *v[i];
   }
 };
+
+template<typename T>
+std::vector<T> extract_vector(boost::python::list py_list) {
+    return std::vector<T>(
+        boost::python::stl_input_iterator<T>(py_list),
+        boost::python::stl_input_iterator<T>()
+    );
+}
+template<typename T>
+boost::python::list to_python_list(const std::vector<T>& vec) {
+    boost::python::list py_list;
+    for (const auto& item : vec) {
+        py_list.append(item);
+    }
+    return py_list;
+}
+
 }  // namespace pyhpp
 
 #endif  // PYHPP_FWD_HH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,4 +160,3 @@ add_python_library(
   pyhpp/manipulation/urdf FILES pyhpp/manipulation/urdf/util.cc
   pyhpp/manipulation/urdf/bindings.cc LINK_LIBRARIES
   hpp-manipulation-urdf::hpp-manipulation-urdf)
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ add_python_library(
   pyhpp/constraints/implicit.cc
   pyhpp/constraints/iterative-solver.cc
   pyhpp/constraints/by-substitution.cc
+  pyhpp/constraints/locked-joint.cc
   pyhpp/constraints/bindings.cc
   LINK_LIBRARIES
   hpp-constraints::hpp-constraints)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,10 +138,14 @@ add_python_library(
   hpp-core::hpp-core)
 
 add_python_library(
-  pyhpp/core/path_optimization FILES
+  pyhpp/core/path_optimization
+  FILES
   pyhpp/core/path_optimization/spline-gradient-based-abstract.cc
-  pyhpp/core/path_optimization/bindings.cc LINK_LIBRARIES hpp-core::hpp-core hpp-core::hpp-core-gpl)
-  
+  pyhpp/core/path_optimization/bindings.cc
+  LINK_LIBRARIES
+  hpp-core::hpp-core
+  hpp-core::hpp-core-gpl)
+
 add_python_library(
   pyhpp/corbaserver FILES pyhpp/corbaserver/bindings.cc
   pyhpp/corbaserver/server.cc LINK_LIBRARIES hpp-corbaserver::hpp-corbaserver)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,8 +140,8 @@ add_python_library(
 add_python_library(
   pyhpp/core/path_optimization FILES
   pyhpp/core/path_optimization/spline-gradient-based-abstract.cc
-  pyhpp/core/path_optimization/bindings.cc LINK_LIBRARIES hpp-core::hpp-core)
-
+  pyhpp/core/path_optimization/bindings.cc LINK_LIBRARIES hpp-core::hpp-core hpp-core::hpp-core-gpl)
+  
 add_python_library(
   pyhpp/corbaserver FILES pyhpp/corbaserver/bindings.cc
   pyhpp/corbaserver/server.cc LINK_LIBRARIES hpp-corbaserver::hpp-corbaserver)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,6 +149,7 @@ add_python_library(
   pyhpp/manipulation/bindings.cc
   pyhpp/manipulation/device.cc
   pyhpp/manipulation/graph.cc
+  pyhpp/manipulation/problem.cc
   LINK_LIBRARIES
   hpp-manipulation::hpp-manipulation)
 
@@ -156,3 +157,4 @@ add_python_library(
   pyhpp/manipulation/urdf FILES pyhpp/manipulation/urdf/util.cc
   pyhpp/manipulation/urdf/bindings.cc LINK_LIBRARIES
   hpp-manipulation-urdf::hpp-manipulation-urdf)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,8 @@ endmacro()
 
 python_install_on_site(pyhpp __init__.py)
 
+python_install_on_site(pyhpp/manipulation constraint_graph_factory.py)
+
 add_python_library(
   pyhpp/pinocchio
   FILES

--- a/src/pyhpp/constraints/bindings.cc
+++ b/src/pyhpp/constraints/bindings.cc
@@ -45,6 +45,7 @@ BOOST_PYTHON_MODULE(bindings) {
   pyhpp::constraints::exposeGenericTransformations();
   pyhpp::constraints::exposeExplicit();
   pyhpp::constraints::exposeImplicit();
+  pyhpp::constraints::exposeLockedJoint();
   pyhpp::constraints::exposeExplicitConstraintSet();
   pyhpp::constraints::exposeHierarchicalIterativeSolver();
   pyhpp::constraints::exposeBySubstitution();

--- a/src/pyhpp/constraints/generic-transformation.cc
+++ b/src/pyhpp/constraints/generic-transformation.cc
@@ -85,10 +85,10 @@ void exposeGenericTransformations() {
   exposeAbsoluteGenericTransformation<Position>("Position");
   exposeAbsoluteGenericTransformation<Orientation>("Orientation");
   exposeAbsoluteGenericTransformation<Transformation>("Transformation");
-  exposeAbsoluteGenericTransformation<RelativePosition>("RelativePosition");
-  exposeAbsoluteGenericTransformation<RelativeOrientation>(
+  exposeRelativeGenericTransformation<RelativePosition>("RelativePosition");
+  exposeRelativeGenericTransformation<RelativeOrientation>(
       "RelativeOrientation");
-  exposeAbsoluteGenericTransformation<RelativeTransformation>(
+  exposeRelativeGenericTransformation<RelativeTransformation>(
       "RelativeTransformation");
 }
 }  // namespace constraints

--- a/src/pyhpp/constraints/implicit.cc
+++ b/src/pyhpp/constraints/implicit.cc
@@ -43,6 +43,10 @@ namespace pyhpp {
 namespace constraints {
 using namespace hpp::constraints;
 
+static size_type getFunctionOutputSize(const ImplicitPtr_t& constraint){
+  return constraint->function().outputSize();
+}
+
 void exposeImplicit() {
   enum_<ComparisonType>("ComparisonType")
       .value("Equality", Equality)
@@ -56,7 +60,11 @@ void exposeImplicit() {
                                                const ComparisonTypes_t&)
       .PYHPP_DEFINE_METHOD_INTERNAL_REF(Implicit, function)
       .def("parameterSize", &Implicit::parameterSize)
-      .def("rightHandSideSize", &Implicit::rightHandSideSize);
+      .def("rightHandSideSize", &Implicit::rightHandSideSize)
+      .def("getFunctionOutputSize", &getFunctionOutputSize).staticmethod(
+          "getFunctionOutputSize")
+      ;
+
 }
 }  // namespace constraints
 }  // namespace pyhpp

--- a/src/pyhpp/constraints/implicit.cc
+++ b/src/pyhpp/constraints/implicit.cc
@@ -43,7 +43,7 @@ namespace pyhpp {
 namespace constraints {
 using namespace hpp::constraints;
 
-static size_type getFunctionOutputSize(const ImplicitPtr_t& constraint){
+static size_type getFunctionOutputSize(const ImplicitPtr_t& constraint) {
   return constraint->function().outputSize();
 }
 
@@ -61,10 +61,8 @@ void exposeImplicit() {
       .PYHPP_DEFINE_METHOD_INTERNAL_REF(Implicit, function)
       .def("parameterSize", &Implicit::parameterSize)
       .def("rightHandSideSize", &Implicit::rightHandSideSize)
-      .def("getFunctionOutputSize", &getFunctionOutputSize).staticmethod(
-          "getFunctionOutputSize")
-      ;
-
+      .def("getFunctionOutputSize", &getFunctionOutputSize)
+      .staticmethod("getFunctionOutputSize");
 }
 }  // namespace constraints
 }  // namespace pyhpp

--- a/src/pyhpp/constraints/locked-joint.cc
+++ b/src/pyhpp/constraints/locked-joint.cc
@@ -22,6 +22,7 @@
 #include <hpp/pinocchio/liegroup-element.hh>
 #include <hpp/constraints/fwd.hh>
 #include <hpp/pinocchio/device.hh>
+#include <hpp/constraints/comparison-types.hh>
 #include <pyhpp/constraints/fwd.hh>
 
 using namespace boost::python;
@@ -44,9 +45,27 @@ LockedJointPtr_t createLockedJoint(const DevicePtr_t& robot,
   }
 }
 
+LockedJointPtr_t createLockedJointWithComp(const DevicePtr_t& robot,
+                                        const char* jointName,
+                                        const vector_t& config,
+                                        const ComparisonTypes_t& comp) {
+  try {
+    // Get robot in hppPlanner object.
+    JointPtr_t joint = robot->getJointByName(jointName);
+    LiegroupElement lge(config, joint->configurationSpace());
+    LockedJointPtr_t lockedJoint(LockedJoint::create(joint, lge));
+    lockedJoint->comparisonType(comp);
+    return lockedJoint;
+  } catch (const std::exception& exc) {
+    throw std::runtime_error(exc.what());
+  }
+}
+
 void exposeLockedJoint() {
   class_<LockedJoint, bases<Implicit>, LockedJointPtr_t, boost::noncopyable>("LockedJoint", no_init)
       .def("create", &createLockedJoint)
+      .staticmethod("create")
+      .def("createWithComp", &createLockedJointWithComp)
       .staticmethod("create");
 }
 }  // namespace constraints

--- a/src/pyhpp/constraints/locked-joint.cc
+++ b/src/pyhpp/constraints/locked-joint.cc
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2025 CNRS
+// Authors: Paul Sardin
+//
+//
+// This file is part of hpp-python
+// hpp-python is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-python is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-python  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include <boost/python.hpp>
+#include <hpp/constraints/locked-joint.hh>
+#include <hpp/pinocchio/liegroup-element.hh>
+#include <hpp/constraints/fwd.hh>
+#include <hpp/pinocchio/device.hh>
+#include <pyhpp/constraints/fwd.hh>
+
+using namespace boost::python;
+
+namespace pyhpp {
+namespace constraints {
+using namespace hpp::constraints;
+
+LockedJointPtr_t createLockedJoint(const DevicePtr_t& robot,
+                                const char* jointName,
+                                const vector_t& config) {
+  try {
+    // Get robot in hppPlanner object.
+    JointPtr_t joint = robot->getJointByName(jointName);
+    LiegroupElement lge(config, joint->configurationSpace());
+    LockedJointPtr_t lockedJoint(LockedJoint::create(joint, lge));
+    return lockedJoint;
+  } catch (const std::exception& exc) {
+    throw std::runtime_error(exc.what());
+  }
+}
+
+void exposeLockedJoint() {
+  class_<LockedJoint, bases<Implicit>, LockedJointPtr_t, boost::noncopyable>("LockedJoint", no_init)
+      .def("create", &createLockedJoint)
+      .staticmethod("create");
+}
+}  // namespace constraints
+}  // namespace pyhpp

--- a/src/pyhpp/constraints/locked-joint.cc
+++ b/src/pyhpp/constraints/locked-joint.cc
@@ -18,11 +18,11 @@
 // <http://www.gnu.org/licenses/>.
 
 #include <boost/python.hpp>
-#include <hpp/constraints/locked-joint.hh>
-#include <hpp/pinocchio/liegroup-element.hh>
-#include <hpp/constraints/fwd.hh>
-#include <hpp/pinocchio/device.hh>
 #include <hpp/constraints/comparison-types.hh>
+#include <hpp/constraints/fwd.hh>
+#include <hpp/constraints/locked-joint.hh>
+#include <hpp/pinocchio/device.hh>
+#include <hpp/pinocchio/liegroup-element.hh>
 #include <pyhpp/constraints/fwd.hh>
 
 using namespace boost::python;
@@ -32,8 +32,8 @@ namespace constraints {
 using namespace hpp::constraints;
 
 LockedJointPtr_t createLockedJoint(const DevicePtr_t& robot,
-                                const char* jointName,
-                                const vector_t& config) {
+                                   const char* jointName,
+                                   const vector_t& config) {
   try {
     // Get robot in hppPlanner object.
     JointPtr_t joint = robot->getJointByName(jointName);
@@ -46,9 +46,9 @@ LockedJointPtr_t createLockedJoint(const DevicePtr_t& robot,
 }
 
 LockedJointPtr_t createLockedJointWithComp(const DevicePtr_t& robot,
-                                        const char* jointName,
-                                        const vector_t& config,
-                                        const ComparisonTypes_t& comp) {
+                                           const char* jointName,
+                                           const vector_t& config,
+                                           const ComparisonTypes_t& comp) {
   try {
     // Get robot in hppPlanner object.
     JointPtr_t joint = robot->getJointByName(jointName);
@@ -62,7 +62,8 @@ LockedJointPtr_t createLockedJointWithComp(const DevicePtr_t& robot,
 }
 
 void exposeLockedJoint() {
-  class_<LockedJoint, bases<Implicit>, LockedJointPtr_t, boost::noncopyable>("LockedJoint", no_init)
+  class_<LockedJoint, bases<Implicit>, LockedJointPtr_t, boost::noncopyable>(
+      "LockedJoint", no_init)
       .def("create", &createLockedJoint)
       .staticmethod("create")
       .def("createWithComp", &createLockedJointWithComp)

--- a/src/pyhpp/core/problem.cc
+++ b/src/pyhpp/core/problem.cc
@@ -37,7 +37,6 @@ namespace core {
 
 using namespace boost::python;
 
-Problem::Problem(const hpp::core::ProblemPtr_t& object) { obj = object; }
 Problem::Problem(const DevicePtr_t& robot)
     : obj(hpp::core::Problem::create(robot)) {}
 

--- a/src/pyhpp/manipulation/bindings.cc
+++ b/src/pyhpp/manipulation/bindings.cc
@@ -37,5 +37,8 @@ BOOST_PYTHON_MODULE(bindings) {
   boost::python::import("pyhpp.pinocchio");
   boost::python::import("pyhpp.constraints");
   pyhpp::manipulation::exposeHandle();
+  pyhpp::manipulation::exposeProblem();
   pyhpp::manipulation::exposeDevice();
+  pyhpp::manipulation::exposeGraph();
+
 }

--- a/src/pyhpp/manipulation/bindings.cc
+++ b/src/pyhpp/manipulation/bindings.cc
@@ -40,5 +40,4 @@ BOOST_PYTHON_MODULE(bindings) {
   pyhpp::manipulation::exposeProblem();
   pyhpp::manipulation::exposeDevice();
   pyhpp::manipulation::exposeGraph();
-
 }

--- a/src/pyhpp/manipulation/constraint_graph_factory.py
+++ b/src/pyhpp/manipulation/constraint_graph_factory.py
@@ -1,0 +1,1265 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2025 CNRS
+# Author: Paul Sardin
+#
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+import abc
+import re
+import sys
+import numpy as np
+from pyhpp.constraints import Implicit, LockedJoint
+
+class Constraints:
+    """
+    Container of numerical constraints
+
+    Numerical constraints are stored as
+    \\li grasp,
+    \\li pregrasp, or
+    \\li numerical constraint,
+    """
+
+    def __init__(self, grasps=[], pregrasps=[], numConstraints=[], lockedJoints=[]):
+        if isinstance(grasps, str):
+            raise TypeError("argument grasps should be a list of strings")
+        if isinstance(pregrasps, str):
+            raise TypeError("argument pregrasps should be a list of strings")
+        if isinstance(numConstraints, str):
+            raise TypeError("argument numConstraints should be a list of strings")
+        if lockedJoints != []:
+            from warnings import warn
+
+            warn(
+                "argument lockedJoints in constructor of class "
+                + "hpp.corbaserver.manipulation.constraints.Constraints "
+                + "is deprecated. Locked joints are handled as numerical "
+                + "constraints."
+            )
+            numConstraints.extend(lockedJoints)
+        self._grasps = set(grasps)
+        self._pregrasps = set(pregrasps)
+        self._numConstraints = set(numConstraints)
+
+    def __add__(self, other):
+        res = Constraints(
+            grasps=self._grasps | other._grasps,
+            pregrasps=self._pregrasps | other._pregrasps,
+            numConstraints=self._numConstraints | other._numConstraints,
+        )
+        return res
+
+    def __sub__(self, other):
+        res = Constraints(
+            grasps=self._grasps - other._grasps,
+            pregrasps=self._pregrasps - other._pregrasps,
+            numConstraints=self._numConstraints - other._numConstraints,
+        )
+        return res
+
+    def __iadd__(self, other):
+        self._grasps |= other._grasps
+        self._pregrasps |= other._pregrasps
+        self._numConstraints |= other._numConstraints
+        return self
+
+    def __isub__(self, other):
+        self._grasps -= other._grasps
+        self._pregrasps -= other._pregrasps
+        self._numConstraints -= other._numConstraints
+        return self
+
+    def empty(self):
+        for s in [self._grasps, self._pregrasps, self._numConstraints]:
+            if len(s) > 0:
+                return False
+        return True
+
+    @property
+    def grasps(self):
+        return list(self._grasps)
+
+    @property
+    def pregrasps(self):
+        return list(self._pregrasps)
+
+    @property
+    def numConstraints(self):
+        return list(self._numConstraints)
+
+    def __str__(self):
+        res = "constraints\n"
+        res += "  grasps: "
+        for c in self._grasps:
+            res += c + ", "
+        res += "\n  pregrasps: "
+        for c in self._pregrasps:
+            res += c + ", "
+        res += "\n  numConstraints: "
+        for c in self._numConstraints:
+            res += c + ", "
+        return res
+
+class PossibleGrasps:
+    def __init__(self, grippers, handles, grasps):
+        """
+        Constructor
+        param grasps a dictionaty whose keys are the grippers registered in the
+               factory and whose values are lists of handles also registered in
+               the factory
+        """
+        self.possibleGrasps = list()
+        for ig, gripper in enumerate(grippers):
+            handles_ = grasps.get(gripper, list())
+            handleIndices = list()
+            handleIndices = list(map(handles.index, handles_))
+            self.possibleGrasps.append(handleIndices)
+
+    def __call__(self, grasps):
+        for ig, ih in enumerate(grasps):
+            if ih is not None and ih not in self.possibleGrasps[ig]:
+                return False
+        return True
+
+
+class GraspIsAllowed:
+    """Class that stores grasp validation instances"""
+
+    def __init__(self):
+        """
+        Successively calls all the validation instances
+         param grasps the set of grasp to validate
+         return False if one validation fails, True otherwise
+        """
+        self.graspValidations_ = list()
+
+    def __call__(self, grasps):
+        for gv in self.graspValidations_:
+            if not gv(grasps):
+                return False
+        return True
+
+    def append(self, graspValidation):
+        self.graspValidations_.append(graspValidation)
+
+
+class Rules:
+    def __init__(self, grippers, handles, rules):
+        rs = []
+        status = []
+        for r in rules:
+            # replace empty strings by the corresponding regexp "^$",
+            # otherwise "" matches with all strings.
+            for i in range(len(r.grippers)):
+                if r.grippers[i] == "":
+                    r.grippers[i] = "^$"
+            for i in range(len(r.handles)):
+                if r.handles[i] == "":
+                    r.handles[i] = "^$"
+            handlesRegex = [None] * len(grippers)
+            for j, gr in enumerate(r.grippers):
+                grc = re.compile(gr)
+                for i, g in enumerate(grippers):
+                    if grc.match(g):
+                        assert handlesRegex[i] is None
+                        handlesRegex[i] = re.compile(r.handles[j])
+            status.append(r.link)
+
+            rs.append(tuple(handlesRegex))
+        self.rules = tuple(rs)
+        self.status = tuple(status)
+        self.handles = tuple(handles)
+        self.defaultAcceptation = False
+
+    def __call__(self, grasps):
+        for r, s in zip(self.rules, self.status):
+            apply = True
+            for i, h in enumerate(r):
+                if h is not None and not h.match(
+                    "" if grasps[i] is None else self.handles[grasps[i]]
+                ):
+                    # This rule does not apply
+                    apply = False
+                    break
+            if apply:
+                return s
+        return self.defaultAcceptation
+
+
+if sys.version_info.major == 2:
+
+    class ABC:
+        """Python 2.7 equivalent to abc.ABC Python 3 class."""
+
+        __metaclass__ = abc.ABCMeta
+
+else:
+    from abc import ABC
+
+
+class GraphFactoryAbstract(ABC):
+    """
+    An abstract class which is loops over the different (gripper, handle) associations.
+
+    The behaviour can be tuned by setting the callback functions:
+    - \\ref graspIsAllowed (redundant with \\ref setRules)
+    - \\ref constraint_graph_factory_algo_callbacks "Algorithm steps"
+
+    <b>Sketch of the algorithm</b>
+
+    Let
+     \\li \\f$G\\f$ be the set of grippers,
+     \\li \\f$H\\f$ be the set of handles.
+
+     A \b grasp is defined as a pair \\f$(g,h)\\in G\\times H\\f$.
+
+     Each \b state (excluding waypoint states) is defined by a set of grasps.
+     Given a set of grasps, we define
+     \\li <b>available grippers</b> as the grippers that are not the first
+         element of any pair of the set of grasps,
+     \\li <b>available handles</b> as the handles that are not the second element
+        of any pair of the set of grasps.
+
+     The first node is defined by the empty set. The graph is built recursiveley
+     as follows:
+
+     if the set of grasps defining the node is not allowed (method \\link
+         constraint_graph_factory.GraphFactoryAbstract.graspIsAllowed
+         graspIsAllowed \\endlink), return.
+
+     Otherwise, for any pair \\f$(g,h)\f$ of available grippers and available
+     handles,
+     \\li build a new state by adding grasp \\f$(g,h)\\f$ to the current set of
+         grasps (method
+         \\link constraint_graph_factory.GraphFactoryAbstract.makeState
+         makeState\\endlink),
+     \\li build a transition from the current state to the new state (method \\link
+         constraint_graph_factory.GraphFactoryAbstract.makeTransition
+         makeTransition \\endlink)
+     \\li build a loopTransition from the current state to itself (method \\link
+         constraint_graph_factory.GraphFactoryAbstract.makeLoopTransition
+         makeLoopTransition \\endlink)
+     \\li repeat the two above states to the new state.
+    """
+
+    def __init__(self):
+        # # Reduces the problem combinatorial.
+        # Function called to check whether a grasps is allowed.
+        # It takes as input a list of handle indices (or None) such
+        # that i-th \\ref grippers grasps `grasps[i]`-th \\ref handles.
+        # It must return a boolean
+        #
+        # It defaults to: \code lambda x : True
+        self.graspIsAllowed = GraspIsAllowed()
+
+        # # \name Internal variables
+        # \{
+
+        self.states = dict()
+        self.transitions = set()
+        # # the handle names
+        self.handles = tuple()  # strings
+        # # the gripper names
+        self.grippers = tuple()  # strings
+        # # the names of contact on the environment
+        self.envContacts = tuple()  # strings
+        # # the object names
+        self.objects = tuple()  # strings
+        # # See \\ref setObjects
+        self.handlesPerObjects = tuple()  # object index to handle indixes
+        # # See \\ref setObjects
+        self.objectFromHandle = tuple()  # handle index to object index
+        # # See \\ref setObjects
+        self.contactsPerObjects = tuple()  # object index to contact names
+        # # \}
+
+    # # \name Main API
+    # \{
+
+    def setGrippers(self, grippers):
+        """
+        \\param grippers list of gripper names to be considered
+        """
+        assert isinstance(grippers, (list, tuple))
+        self.grippers = tuple(grippers)
+
+    def setObjects(self, objects, handlesPerObjects, contactsPerObjects):
+        """
+        \\param objects list of object names to be considered
+        \\param handlesPerObjects a list of list of handle names.
+        \\param contactsPerObjects a list of list of contact names.
+         handlesPerObjects and contactsPerObjects must have one list for each object,
+         in the same order.
+        """
+        if len(objects) != len(handlesPerObjects):
+            raise IndexError("There should be as many handlesPerObjects as objects")
+        if len(objects) != len(contactsPerObjects):
+            raise IndexError("There should be as many contactsPerObjects as objects")
+        self.objects = tuple(objects)
+        handles = []
+        hpo = []
+        cpo = []
+        ofh = []
+        for io, o in enumerate(self.objects):
+            hpo.append(
+                tuple(range(len(handles), len(handles) + len(handlesPerObjects[io])))
+            )
+            handles.extend(handlesPerObjects[io])
+            ofh.extend([io] * len(handlesPerObjects[io]))
+            cpo.append(tuple(contactsPerObjects[io]))
+
+        self.handles = tuple(handles)
+        self.handlesPerObjects = tuple(hpo)
+        self.objectFromHandle = tuple(ofh)
+        self.contactsPerObjects = tuple(cpo)
+
+    def environmentContacts(self, envContacts):
+        """
+        \\param envContacts contact on the environment to be considered.
+        """
+        self.envContacts = tuple(envContacts)
+
+    def setRules(self, rules):
+        """
+        Set the function \\ref graspIsAllowed
+        \\param rules a list of Rule objects
+        """
+        self.graspIsAllowed.append(Rules(self.grippers, self.handles, rules))
+
+    def setPossibleGrasps(self, grasps):
+        """
+        Define the possible grasps
+        \\param grasps a dictionaty whose keys are the grippers registered in
+                the factory and whose values are lists of handles also
+                registered in the factory
+        """
+        self.graspIsAllowed.append(PossibleGrasps(self.grippers, self.handles, grasps))
+
+    def generate(self):
+        """
+        Go through the combinatorial defined by the grippers and handles
+        and create the states and transitions.
+        """
+        grasps = (None,) * len(self.grippers)
+        self._recurse(self.grippers, self.handles, grasps, 0)
+
+    # # \}
+
+    # # \name Abstract methods of the algorithm
+    #  \anchor constraint_graph_factory_algo_callbacks
+    # \{
+
+    @abc.abstractmethod
+    def makeState(self, grasps, priority):
+        """
+        Create a new state.
+        \\param grasps a handle index for each gripper,
+                as in GraphFactoryAbstract.graspIsAllowed.
+        \\param priority the state priority.
+        \\return an object representing the state.
+        """
+        return grasps
+
+    @abc.abstractmethod
+    def makeLoopTransition(self, state):
+        """
+        Create a loop transition.
+        \\param state: an object returned by \\ref makeState which represent the state
+        """
+        pass
+
+    def transitionIsAllowed(self, stateFrom, stateTo):
+        """
+        Check whether a transition between two states is allowed
+        \\param stateFrom, stateTo states to connect
+        """
+        return True
+
+    @abc.abstractmethod
+    def makeTransition(self, stateFrom, stateTo, ig):
+        """
+        Create two transitions between two different states.
+        \\param stateFrom: same as grasps in \\ref makeState
+        \\param stateTo: same as grasps in \\ref makeState
+        \\param ig: index if the grasp vector that changes, i.e. such that
+          - \\f$ stateFrom.grasps[i_g] \neq stateTo.grasps[i_g] \\f$
+          - \\f$ \\forall i \neq i_g, stateFrom.grasps[i] = stateTo.grasps[i] \\f$
+        """
+        pass
+
+    # # \}
+
+    def _existState(self, grasps):
+        return grasps in self.states
+
+    def _makeState(self, grasps, priority):
+        if not self._existState(grasps):
+            state = self.makeState(grasps, priority)
+            self.states[grasps] = state
+
+            # Create loop transition
+            self.makeLoopTransition(state)
+        else:
+            state = self.states[grasps]
+        return state
+
+    def _isObjectGrasped(self, grasps, object):
+        for h in self.handlesPerObjects[object]:
+            if h in grasps:
+                return True
+        return False
+
+    def _stateName(self, grasps, abbrev=False):
+        sepGH = "-" if abbrev else " grasps "
+        sep = ":" if abbrev else " : "
+        name = sep.join(
+            [
+                (str(ig) if abbrev else self.grippers[ig])
+                + sepGH
+                + (str(ih) if abbrev else self.handles[ih])
+                for ig, ih in enumerate(grasps)
+                if ih is not None
+            ]
+        )
+        if len(name) == 0:
+            return "f" if abbrev else "free"
+        return name
+
+    def _transitionNames(self, sFrom, sTo, ig):
+        g = self.grippers[ig]
+        h = self.handles[sTo.grasps[ig]]
+        sep = " | "
+        return (
+            g + " > " + h + sep + self._stateName(sFrom.grasps, True),
+            g + " < " + h + sep + self._stateName(sTo.grasps, True),
+        )
+
+    def _loopTransitionName(self, grasps):
+        return "Loop | " + self._stateName(grasps, True)
+
+    def _recurse(self, grippers, handles, grasps, depth):
+        """
+        Recurse across all possible sets of grasps
+
+        This method visits all possible set of grasps and create states
+        and transitions between those states.
+
+        \\param grippers list of names of available grippers: that do not hold
+               an handle yet,
+        \\param handles list of names of available handles that are not hold yet
+               by a gripper.
+        \\param grasps list of grasps already active. Grasps are represented by
+               a list of handle indices or None if the gripper is available.
+               the order in the list corresponds to the order of the gripper
+               in the list of all grippers.
+               For instance, if a robot has 3 grippers registered in the factory
+               ("g1", "g2", "g3"), handles ["h1", "h2"] are registered in
+               the factory, and grasps is equal to (1, 0, None), then
+                 \\li "g1" holds "h2",
+                 \\li "g2" holds "h1", and
+                 \\li "g3" does not hold anything.
+
+        """
+        isAllowed = self.graspIsAllowed(grasps)
+        if isAllowed:
+            current = self._makeState(grasps, depth)
+
+        if len(grippers) == 0 or len(handles) == 0:
+            return
+        for ig, g in enumerate(grippers):
+            # ngrippers = { grippers } \ grippers[ig]
+            ngrippers = grippers[:ig] + grippers[ig + 1 :]
+            # isg <- index of g in list of all grippers
+            isg = self.grippers.index(g)
+            for ih, h in enumerate(handles):
+                # nhandles = { handles } \ handles[ih]
+                nhandles = handles[:ih] + handles[ih + 1 :]
+                # ish <- index of h in all handles
+                ish = self.handles.index(h)
+                # nGrasp <- substitute current handle index at current gripper
+                # position.
+                nGrasps = grasps[:isg] + (ish,) + grasps[isg + 1 :]
+
+                nextIsAllowed = self.graspIsAllowed(nGrasps)
+                isNewState = not self._existState(nGrasps)
+                if nextIsAllowed:
+                    nnext = self._makeState(nGrasps, depth + 1)
+
+                if (
+                    isAllowed
+                    and nextIsAllowed
+                    and self.transitionIsAllowed(stateFrom=current, stateTo=nnext)
+                ):
+                    self.makeTransition(current, nnext, isg)
+
+                if isNewState:
+                    self._recurse(ngrippers, nhandles, nGrasps, depth + 2)
+
+
+class ConstraintFactoryAbstract(ABC):
+    """
+    An abstract class which stores the constraints.
+
+    Child classes are responsible for building them.
+    - \\ref buildGrasp
+    - \\ref buildPlacement
+    """
+
+    def __init__(self, graphfactory):
+        self._grasp = dict()
+        self._placement = dict()
+
+        self.graphfactory = graphfactory
+
+    # # \name Accessors to the different elementary constraints
+    # \{
+
+    def getGrasp(self, gripper, handle):
+        """
+        Get constraints relative to a grasp
+
+        \\param gripper name of a gripper or gripper index
+        \\param handle name of a handle or handle index
+        \\return a dictionary with keys <c>['grasp', 'graspComplement',
+                'preGrasp']</c> and values the corresponding constraints as
+                \\link manipulation.constraints.Constraints Constraints\\endlink
+                instances.
+        \\warning If grasp does not exist, the function creates it.
+        """
+        if isinstance(gripper, str):
+            ig = self.graphfactory.grippers.index(gripper)
+        else:
+            ig = gripper
+        if isinstance(handle, str):
+            ih = self.graphfactory.handles.index(handle)
+        else:
+            ih = handle
+        k = (ig, ih)
+        if k not in self._grasp:
+            self._grasp[k] = self.buildGrasp(
+                self.graphfactory.grippers[ig],
+                None if ih is None else self.graphfactory.handles[ih],
+            )
+            assert isinstance(self._grasp[k], dict)
+        return self._grasp[k]
+
+    def g(self, gripper, handle, what):
+        """
+        Get constraints relative to a grasp
+
+        \\param gripper name of a gripper or gripper index,
+        \\param handle name of a handle or handle index,
+        \\param what a word among <c>['grasp', 'graspComplement', 'preGrasp']</c>.
+        \\return the corresponding constraints as
+                \\link manipulation.constraints.Constraints Constraints\\endlink
+                instances.
+        \\warning If grasp does not exist, the function creates it.
+        """
+        return self.getGrasp(gripper, handle)[what]
+
+    def getPlacement(self, object):
+        """
+        Get constraints relative to an object placement
+
+        \\param object object name or index
+        \\return a dictionary with keys <c>['placement', 'placementComplement',
+                'prePlacement']</c> and values the corresponding constraints as
+                \\link manipulation.constraints.Constraints Constraints\\endlink
+                instances.
+        \\warning If placement does not exist, the function creates it.
+        """
+        if isinstance(object, str):
+            io = self.graphfactory.objects.index(object)
+        else:
+            io = object
+        k = io
+        if k not in self._placement:
+            self._placement[k] = self.buildPlacement(self.graphfactory.objects[io])
+        return self._placement[k]
+
+    def p(self, object, what):
+        """
+        Get constraints relative to a placement
+
+        \\param object object name or index
+        \\param what a word among <c>['placement', 'placementComplement',
+               'prePlacement']</c>.
+        \\return the corresponding constraints as
+                \\link manipulation.constraints.Constraints Constraints\\endlink
+                instances.
+        \\warning If placement does not exist, the function creates it.
+        """
+        return self.getPlacement(object)[what]
+
+    # # \}
+
+    @abc.abstractmethod
+    def buildGrasp(self, g, h):
+        """
+        Function called to create grasp constraints.
+        Must return a tuple of Constraints objects as:
+        - constraint that validates the grasp
+        - constraint that parameterizes the graph
+        - constraint that validates the pre-grasp
+        \\param g gripper string
+        \\param h handle  string
+        """
+        return (
+            None,
+            None,
+            None,
+        )
+
+    @abc.abstractmethod
+    def buildPlacement(self, o):
+        """
+        Function called to create placement constraints.
+        Must return a tuple of Constraints objects as:
+        - constraint that validates placement
+        - constraint that parameterizes placement
+        - constraint that validates pre-placement
+        \\param o string
+        """
+        return (
+            None,
+            None,
+            None,
+        )
+
+
+class ConstraintFactory(ConstraintFactoryAbstract):
+    """
+    Default implementation of ConstraintFactoryAbstract
+    """
+
+    removeEmptyConstraints = True
+    """
+    This flag determines whether preplacement states are added when no
+    contact surface is present. Setting it to false may be useful in order
+    to keep the same graph topology and to populate the graph with dedicated
+    constraints.
+    """
+
+    def _removeEmptyConstraints(self, constraints):
+        if self.removeEmptyConstraints:
+            return [
+                n
+                for n in constraints
+                if n in self.available_constraints
+                and Implicit.getFunctionOutputSize(self.available_constraints[n]) > 0
+            ]
+        else:
+            return constraints
+
+    gfields = ("grasp", "graspComplement", "preGrasp")
+    pfields = ("placement", "placementComplement", "prePlacement")
+
+    def __init__(self, graphfactory, graph, constraints = dict()):
+        super().__init__(graphfactory)
+        self.graph = graph
+        self.available_constraints = dict()
+        self.registerConstraints(constraints)
+
+    def registerConstraint(self, constraint, constraint_name):
+        """Register a single constraint as available"""
+        self.available_constraints[constraint_name] = constraint
+
+    def registerConstraints(self, constraint_dict):
+        """Register multiple constraints as available"""
+        self.available_constraints.update(constraint_dict)
+
+    def buildGrasp(self, g, h):
+        """
+        Calls ConstraintGraph.createGraph and ConstraintGraph.createPreGrasp
+        \\param g gripper string
+        \\param h handle  string
+        \note if the grasp constraint already exists, it is not created.
+        """
+        n = g + " grasps " + h
+        pn = g + " pregrasps " + h
+        graspAlreadyCreated = n in self.available_constraints
+        pregraspAlreadyCreated = pn in self.available_constraints
+        if not graspAlreadyCreated:
+            cname = n + "/complement";
+            bname = n + "/hold";
+            gripper = self.graph.robot.grippers()[g]
+            handle = self.graph.robot.handles()[h]
+            constraint = handle.createGrasp(gripper, n)
+            complement = handle.createGraspComplement(gripper, cname)
+            both = handle.createGraspAndComplement(gripper, bname)
+            self.registerConstraint(constraint, n)
+            self.registerConstraint(complement, cname)
+            self.registerConstraint(both, bname)
+        if not pregraspAlreadyCreated:
+            gripper = self.graph.robot.grippers()[g]
+            handle = self.graph.robot.handles()[h]
+            c = handle.clearance + gripper.clearance
+            pregrasp = handle.createPreGrasp(gripper, c, pn)
+            self.registerConstraint(pregrasp, pn)
+        return dict(
+            list(
+                zip(
+                    self.gfields,
+                    (
+                        Constraints(
+                            numConstraints=self._removeEmptyConstraints(
+                                [
+                                    n,
+                                ],
+                            )
+                        ),
+                        Constraints(
+                            numConstraints=self._removeEmptyConstraints(
+                                [
+                                    n + "/complement",
+                                ],
+                            )
+                        ),
+                        Constraints(
+                            numConstraints=self._removeEmptyConstraints(
+                                [
+                                    pn,
+                                ],
+                            )
+                        ),
+                    ),
+                )
+            )
+        )
+
+    def buildPlacement(self, o):
+        """
+        This implements placement manifolds,
+        where the parameterization constraints is the complement
+        of the placement constraint.
+        \\param o string
+        """
+        n = "place_" + o
+        pn = "preplace_" + o
+        # Get distance of object to surface in preplacement
+        distance = self.graphfactory.getPreplacementDistance(o)
+        io = self.graphfactory.objects.index(o)
+        placeAlreadyCreated = n in self.available_constraints
+        if (
+            len(self.graphfactory.contactsPerObjects[io]) == 0
+            or len(self.graphfactory.envContacts) == 0
+        ) and not placeAlreadyCreated:
+            ljs = []
+            for n in self.graph.robot.getJointNames():
+                if n.startswith(o + "/"):
+                    ljs.append(n)
+                    q = self.graph.robot.getJointConfig(n)
+                    self.registerConstraint(LockedJoint.create(self.graph.robot.asPinDevice(), n, np.array(q)), n)
+            return dict(
+                list(
+                    zip(
+                        self.pfields,
+                        (
+                            Constraints(),
+                            Constraints(numConstraints=ljs),
+                            Constraints(),
+                        ),
+                    )
+                )
+            )
+        if not placeAlreadyCreated:
+            constraint, complement, both = self.graph.createPlacementConstraint(
+                n,
+                list(self.graphfactory.contactsPerObjects[io]),
+                list(self.graphfactory.envContacts),
+            )
+            self.registerConstraint(constraint, n)
+            self.registerConstraint(complement, n + "/complement")
+            if both:
+                self.registerConstraint(both, n + "/hold")
+        if pn not in self.available_constraints:
+            preplace_constraint = self.graph.createPrePlacementConstraint(
+                pn,
+                list(self.graphfactory.contactsPerObjects[io]),
+                list(self.graphfactory.envContacts),
+                distance,
+            )
+            self.registerConstraint(preplace_constraint, pn)
+        return dict(
+            list(
+                zip(
+                    self.pfields,
+                    (
+                        Constraints(
+                            numConstraints=self._removeEmptyConstraints(
+                                [
+                                    n,
+                                ],
+                            )
+                        ),
+                        Constraints(
+                            numConstraints=self._removeEmptyConstraints(
+                                [
+                                    n + "/complement",
+                                ],
+                            )
+                        ),
+                        Constraints(
+                            numConstraints=self._removeEmptyConstraints(
+                                [
+                                    pn,
+                                ],
+                            )
+                        ),
+                    ),
+                )
+            )
+        )
+
+
+class ConstraintGraphFactory(GraphFactoryAbstract):
+    """
+    Default implementation of ConstraintGraphFactory
+
+    The minimal usage is the following:
+    >>> graph = ConstraintGraph(robot, "graph")
+
+    # Required calls
+    >>> factory = ConstraintGraphFactory(graph)
+    >>> factory.setGrippers(["gripper1", ... ])
+    >>> factory.setObjects(["object1", ], [ [ "object1/handle1", ... ] ], [ [] ])
+
+    # Optionally
+    >>> factory.environmentContacts(["contact1", ... ])
+    >>> factory.setRules([ Rule(["gripper1", ..], ["handle1", ...], True), ... ])
+
+    >>> factory.generate()
+
+    # graph is initialized
+    """
+
+    class StateAndManifold:
+        def __init__(self, factory, grasps, state_obj, name):
+            self.grasps = grasps
+            self.state_obj = state_obj
+            self.name = name
+            self.manifold = Constraints()
+            self.foliation = Constraints()
+            # Add the grasps
+            for ig, ih in enumerate(grasps):
+                if ih is not None:
+                    self.manifold += factory.constraints.g(ig, ih, "grasp")
+                    self.foliation += factory.constraints.g(ig, ih, "graspComplement")
+            # Add the placement constraints
+            for io, object in enumerate(factory.objects):
+                if not factory._isObjectGrasped(grasps, io):
+                    self.manifold += factory.constraints.p(object, "placement")
+                    self.foliation += factory.constraints.p(
+                        object, "placementComplement"
+                    )
+
+    # default distance between object and surface in preplacement configuration
+    defaultPreplaceDist = 0.05
+    # See methods setPreplacementDistance and getPreplacementDistance
+    preplaceDistance = dict()
+
+    def __init__(self, graph, constraints = dict()):
+        """
+        \\param graph an instance of ConstraintGraph
+        """
+        super().__init__()
+
+        # Stores the constraints in a child class of ConstraintFactoryAbstract
+        self.constraints = ConstraintFactory(self, graph, constraints)
+
+        self.graph = graph
+
+        # whether there should be placement complement in transition from
+        # intersec to preplace
+        self.preplaceGuide = False
+        self.state_objects = {}
+        self.edge_objects = {}
+
+    # # \name Default functions
+    # \{
+
+    def makeState(self, grasps, priority):
+        # Create state
+        name = self._stateName(grasps)
+        state_obj = self.graph.createState(name, False, priority)
+        state = ConstraintGraphFactory.StateAndManifold(self, grasps, state_obj, name)
+
+        # Add the constraints
+        self._add_constraints_to_state(state_obj, state.manifold)
+        return state
+
+    def makeLoopTransition(self, state):
+        n = self._loopTransitionName(state.grasps)
+        loop_edge = self.graph.createTransition(
+            state.state_obj, state.state_obj, n, 0, state.state_obj
+        )
+        self.edge_objects[n] = loop_edge 
+        self._add_constraints_to_transition(loop_edge, state.foliation)
+
+    def makeTransition(self, stateFrom, stateTo, ig):
+        """
+        Make transition between two states using boost python API
+        
+        \\param stateFrom initial state,
+        \\param stateTo new state
+        \\param ig index of gripper
+        
+        stateTo grasps are the union of stateFrom grasps with a set containing
+        a grasp by gripper of index ig in list <c>self.grippers</c> of a handle.
+        The index of the newly grasped handle can be found by
+        <c>stateTo.grasps[ig]</c>
+        """
+        sf = stateFrom
+        st = stateTo
+        names = self._transitionNames(sf, st, ig)
+        if names in self.transitions:
+            return
+
+        ih = st.grasps[ig]
+        iobj = self.objectFromHandle[ih]
+        noPlace = self._isObjectGrasped(sf.grasps, iobj)
+
+        gc = self.constraints.g(ig, ih, "grasp")
+        gcc = self.constraints.g(ig, ih, "graspComplement")
+        pgc = self.constraints.g(ig, ih, "preGrasp")
+        
+        if noPlace:
+            pc = Constraints()
+            pcc = Constraints()
+            ppc = Constraints()
+        else:
+            pc = self.constraints.p(self.objectFromHandle[ih], "placement")
+            pcc = self.constraints.p(self.objectFromHandle[ih], "placementComplement")
+            ppc = self.constraints.p(self.objectFromHandle[ih], "prePlacement")
+        
+        manifold = sf.manifold - pc
+
+        # The different cases:
+        pregrasp = not pgc.empty()
+        intersec = (not gc.empty()) and (not pc.empty())
+        preplace = not ppc.empty()
+
+        nWaypoints = pregrasp + intersec + preplace
+        nTransitions = 1 + nWaypoints
+
+        # Check whether level set edge is required
+        assert len(sf.foliation.grasps) == 0
+        assert len(sf.foliation.pregrasps) == 0
+        assert len(st.foliation.grasps) == 0
+        assert len(st.foliation.pregrasps) == 0
+        crossedFoliation = False
+        if (
+            len(sf.foliation.numConstraints) > 0
+            and len(st.foliation.numConstraints) > 0
+        ):
+            crossedFoliation = True
+
+        def _createWaypointState(name, constraints):
+            """Create waypoint state using boost python API"""
+            waypoint_state = self.graph.createState(name, True, 0)
+            self.state_objects[name] = waypoint_state
+            self._add_constraints_to_state(waypoint_state, constraints)
+            return name
+
+        wStates = [sf.name]
+        wStateObjects = [sf.state_obj]
+        
+        if pregrasp:
+            pregrasp_name = names[0] + "_pregrasp"
+            _createWaypointState(pregrasp_name, pc + pgc + manifold)
+            wStates.append(pregrasp_name)
+            wStateObjects.append(self.state_objects[pregrasp_name])
+            
+        if intersec:
+            intersec_name = names[0] + "_intersec"
+            _createWaypointState(intersec_name, pc + gc + manifold)
+            wStates.append(intersec_name)
+            wStateObjects.append(self.state_objects[intersec_name])
+            
+        if preplace:
+            preplace_name = names[0] + "_preplace"
+            _createWaypointState(preplace_name, ppc + gc + manifold)
+            wStates.append(preplace_name)
+            wStateObjects.append(self.state_objects[preplace_name])
+        
+        wStates.append(st.name)
+        wStateObjects.append(st.state_obj)
+
+        if nWaypoints > 0:
+            forward_edge = self.graph.createWaypointTransition(
+                sf.state_obj, st.state_obj, names[0], nWaypoints, 1, sf.state_obj, False
+            )
+            backward_edge = self.graph.createWaypointTransition(
+                st.state_obj, sf.state_obj, names[1], nWaypoints, 1, sf.state_obj, False
+            )
+            
+            self.edge_objects[names[0]] = forward_edge
+            self.edge_objects[names[1]] = backward_edge
+            
+            forward_ls_edge = None
+            backward_ls_edge = None
+            
+            if crossedFoliation:
+                forward_ls_edge = self.graph.createWaypointTransition(
+                    sf.state_obj, st.state_obj, names[0] + "_ls", nWaypoints, 10, sf.state_obj, False
+                )
+                self.edge_objects[names[0] + "_ls"] = forward_ls_edge
+                
+                if not noPlace:
+                    backward_ls_edge = self.graph.createWaypointTransition(
+                        st.state_obj, sf.state_obj, names[1] + "_ls", nWaypoints, 10, sf.state_obj, False
+                    )
+                    self.edge_objects[names[1] + "_ls"] = backward_ls_edge
+            
+            wTransitions = []
+            wTransitionObjects = []
+            
+            for i in range(nTransitions):
+                nf = f"{names[0]}_{i}{i + 1}"
+                nb = f"{names[1]}_{i + 1}{i}"
+                
+                forward_trans = self.graph.createTransition(
+                    wStateObjects[i], wStateObjects[i + 1], nf, -1, wStateObjects[i]
+                )
+                backward_trans = self.graph.createTransition(
+                    wStateObjects[i + 1], wStateObjects[i], nb, -1, wStateObjects[i]
+                )
+                self.edge_objects[nf] = forward_trans
+                self.edge_objects[nb] = backward_trans
+                
+                nf_ls = nf
+                nb_ls = nb
+            
+                if crossedFoliation:
+                    if i == 0:
+                        edgeName = nf_ls = nf + "_ls"
+                        containingState = sf.state_obj  # containing state is always start state
+                        level_set_edge_forward = self.graph.createLevelSetTransition(
+                            wStateObjects[i], wStateObjects[i + 1], edgeName, -1, containingState
+                        )
+                        self.edge_objects[edgeName] = level_set_edge_forward
+                        
+                        paramNC_constraints = self._get_constraint_objects(
+                            (st.foliation - sf.foliation).numConstraints
+                        )
+                        condNC_constraints = self._get_constraint_objects(
+                            (st.manifold - sf.manifold).numConstraints
+                        )
+                        
+                        self.graph.addLevelSetFoliation(
+                            level_set_edge_forward, condNC_constraints, paramNC_constraints
+                        )
+                        self._add_constraints_to_transition(level_set_edge_forward, sf.foliation)
+                    
+                    if i == nTransitions - 1 and crossedFoliation:
+                        edgeName = nb_ls = nb + "_ls"
+                        # containing state is goal state if an object in placement is grasped, start state otherwise
+                        if not noPlace:
+                            containingState = st.state_obj
+                            level_set_edge_backward = self.graph.createLevelSetTransition(
+                                wStateObjects[i + 1], wStateObjects[i], edgeName, -1, containingState
+                            )
+                            self.edge_objects[edgeName] = level_set_edge_backward
+                            
+                            pNC_constraints = self._get_constraint_objects(
+                                (sf.foliation - st.foliation).numConstraints
+                            )
+                            cNC_constraints = self._get_constraint_objects(
+                                sf.manifold.numConstraints
+                            )
+                            
+                            self.graph.addLevelSetFoliation(
+                                level_set_edge_backward, cNC_constraints, pNC_constraints
+                            )
+                            self._add_constraints_to_transition(level_set_edge_backward, st.foliation)
+                    
+                    if forward_ls_edge:
+                        edge_to_use_forward = self.edge_objects[nf_ls] if i == 0 else forward_trans
+                        self.graph.setWaypoint(
+                            forward_ls_edge,
+                            i,
+                            edge_to_use_forward,
+                            wStateObjects[i + 1]
+                        )
+
+                    if backward_ls_edge and not noPlace:
+                        edge_to_use_backward = self.edge_objects[nb_ls] if i == nTransitions - 1 else backward_trans
+                        self.graph.setWaypoint(
+                            backward_ls_edge,
+                            nTransitions - 1 - i,
+                            edge_to_use_backward,
+                            wStateObjects[i]
+                        )
+
+                # Set waypoints for regular edges
+                self.graph.setWaypoint(
+                    forward_edge,
+                    i,
+                    forward_trans,
+                    wStateObjects[i + 1]
+                )
+                self.graph.setWaypoint(
+                    backward_edge,
+                    nTransitions - 1 - i,
+                    backward_trans,
+                    wStateObjects[i]
+                )
+
+                wTransitions.append((nf, nb))
+                wTransitionObjects.append((forward_trans, backward_trans))
+
+            M = 0 if gc.empty() else 1 + pregrasp
+            
+            for i in range(M):
+                forward_trans, backward_trans = wTransitionObjects[i]
+                
+                self.graph.setContainingNode(forward_trans, sf.state_obj)
+                self._add_constraints_to_transition(forward_trans, sf.foliation)
+                
+                self.graph.setContainingNode(backward_trans, sf.state_obj)
+                self._add_constraints_to_transition(backward_trans, sf.foliation)
+            
+            for i in range(M, nTransitions):
+                forward_trans, backward_trans = wTransitionObjects[i]
+                
+                self.graph.setContainingNode(forward_trans, st.state_obj)
+                self._add_constraints_to_transition(forward_trans, st.foliation)
+                
+                self.graph.setContainingNode(backward_trans, st.state_obj)
+                self._add_constraints_to_transition(backward_trans, st.foliation)
+
+            if pregrasp:
+                forward_trans, backward_trans = wTransitionObjects[1]
+                self._add_constraints_to_transition(forward_trans, gcc)
+                self._add_constraints_to_transition(backward_trans, gcc)
+            
+            if intersec and preplace and self.preplaceGuide:
+                forward_trans, backward_trans = wTransitionObjects[pregrasp + intersec]
+                self._add_constraints_to_transition(forward_trans, pcc)
+                self._add_constraints_to_transition(backward_trans, pcc)
+            
+            for i in range(nTransitions - 1):
+                forward_trans, backward_trans = wTransitionObjects[i + 1]
+                self.graph.setShort(forward_trans, True)
+                
+                forward_trans_back, backward_trans_back = wTransitionObjects[i]
+                self.graph.setShort(backward_trans_back, True)
+        
+        else:
+            raise NotImplementedError("This case has not been implemented")
+
+        self.transitions.add(names)
+        # # \}
+
+        # # \name Tuning the constraints
+        #  \{
+
+    def setPreplacementDistance(self, obj, distance):
+        """
+        Set preplacement distance
+        \\param obj name of the object
+        \\param distance distance of object to surface in preplacement
+        configuration
+        """
+        # check that object is registered in factory
+        if obj not in self.objects:
+            raise RuntimeError(
+                obj + " is not references as an object in the " + "factory"
+            )
+        self.preplaceDistance[obj] = distance
+
+    def getPreplacementDistance(self, obj):
+        """
+        Get preplacement distance
+        \\param obj name of the object
+        """
+        # check that object is registered in factory
+        if obj not in self.objects:
+            raise RuntimeError(
+                obj + " is not references as an object in the " + "factory"
+            )
+        return self.preplaceDistance.get(obj, self.defaultPreplaceDist)
+
+    # Set whether we should add placement complement
+    # to the transition between intersec and preplace (if available)
+    def setPreplaceGuide(self, preplaceGuide):
+        self.preplaceGuide = preplaceGuide
+
+    # # \}
+
+    def _add_constraints_to_state(self, state_obj, constraints):
+        """Convert Constraints object to constraint objects and add to state"""
+        constraint_objects = []
+        
+        for constraint_name in constraints.numConstraints:
+            if constraint_name in self.constraints.available_constraints:
+                constraint_obj = self.constraints.available_constraints[constraint_name]
+                constraint_objects.append(constraint_obj)
+        
+        # Handle grasps 
+        for grasp_name in constraints.grasps:
+            if grasp_name in self.constraints.available_constraints:
+                constraint_obj = self.constraints.available_constraints[grasp_name]
+                constraint_objects.append(constraint_obj)
+        
+        # Handle pregrasps
+        for pregrasp_name in constraints.pregrasps:
+            if pregrasp_name in self.constraints.available_constraints:
+                constraint_obj = self.constraints.available_constraints[pregrasp_name]
+                constraint_objects.append(constraint_obj)
+        
+        if constraint_objects:
+            self.graph.addNumericalConstraintsToState(state_obj, constraint_objects)
+
+    def _add_constraints_to_transition(self, edge_obj, constraints):
+        """Convert Constraints object to constraint objects and add to transition"""
+        constraint_objects = []
+        
+        for constraint_name in constraints.numConstraints:
+            if constraint_name in self.constraints.available_constraints:
+                constraint_obj = self.constraints.available_constraints[constraint_name]
+                constraint_objects.append(constraint_obj)
+        
+        if constraint_objects:
+            self.graph.addNumericalConstraintsToTransition(edge_obj, constraint_objects)
+
+    def _get_constraint_objects(self, constraint_names):
+        """Convert list of constraint names to list of constraint objects"""
+        constraint_objects = []
+        for name in constraint_names:
+            if name in self.constraints.available_constraints:
+                constraint_objects.append(self.constraints.available_constraints[name])
+        return constraint_objects
+
+
+
+
+class Rule:
+    def __init__(self, grippers=None, handles=None, link=False):
+        self.grippers = grippers if grippers is not None else []
+        self.handles = handles if handles is not None else []
+        self.link = link

--- a/src/pyhpp/manipulation/constraint_graph_factory.py
+++ b/src/pyhpp/manipulation/constraint_graph_factory.py
@@ -34,6 +34,7 @@ import sys
 import numpy as np
 from pyhpp.constraints import Implicit, LockedJoint
 
+
 class Constraints:
     """
     Container of numerical constraints
@@ -123,6 +124,7 @@ class Constraints:
         for c in self._numConstraints:
             res += c + ", "
         return res
+
 
 class PossibleGrasps:
     def __init__(self, grippers, handles, grasps):
@@ -678,7 +680,7 @@ class ConstraintFactory(ConstraintFactoryAbstract):
     gfields = ("grasp", "graspComplement", "preGrasp")
     pfields = ("placement", "placementComplement", "prePlacement")
 
-    def __init__(self, graphfactory, graph, constraints = dict()):
+    def __init__(self, graphfactory, graph, constraints=dict()):
         super().__init__(graphfactory)
         self.graph = graph
         self.available_constraints = dict()
@@ -704,8 +706,8 @@ class ConstraintFactory(ConstraintFactoryAbstract):
         graspAlreadyCreated = n in self.available_constraints
         pregraspAlreadyCreated = pn in self.available_constraints
         if not graspAlreadyCreated:
-            cname = n + "/complement";
-            bname = n + "/hold";
+            cname = n + "/complement"
+            bname = n + "/hold"
             gripper = self.graph.robot.grippers()[g]
             handle = self.graph.robot.handles()[h]
             constraint = handle.createGrasp(gripper, n)
@@ -773,7 +775,12 @@ class ConstraintFactory(ConstraintFactoryAbstract):
                 if n.startswith(o + "/"):
                     ljs.append(n)
                     q = self.graph.robot.getJointConfig(n)
-                    self.registerConstraint(LockedJoint.create(self.graph.robot.asPinDevice(), n, np.array(q)), n)
+                    self.registerConstraint(
+                        LockedJoint.create(
+                            self.graph.robot.asPinDevice(), n, np.array(q)
+                        ),
+                        n,
+                    )
             return dict(
                 list(
                     zip(
@@ -882,7 +889,7 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
     # See methods setPreplacementDistance and getPreplacementDistance
     preplaceDistance = dict()
 
-    def __init__(self, graph, constraints = dict()):
+    def __init__(self, graph, constraints=dict()):
         """
         \\param graph an instance of ConstraintGraph
         """
@@ -917,17 +924,17 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
         loop_edge = self.graph.createTransition(
             state.state_obj, state.state_obj, n, 0, state.state_obj
         )
-        self.edge_objects[n] = loop_edge 
+        self.edge_objects[n] = loop_edge
         self._add_constraints_to_transition(loop_edge, state.foliation)
 
     def makeTransition(self, stateFrom, stateTo, ig):
         """
         Make transition between two states using boost python API
-        
+
         \\param stateFrom initial state,
         \\param stateTo new state
         \\param ig index of gripper
-        
+
         stateTo grasps are the union of stateFrom grasps with a set containing
         a grasp by gripper of index ig in list <c>self.grippers</c> of a handle.
         The index of the newly grasped handle can be found by
@@ -946,7 +953,7 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
         gc = self.constraints.g(ig, ih, "grasp")
         gcc = self.constraints.g(ig, ih, "graspComplement")
         pgc = self.constraints.g(ig, ih, "preGrasp")
-        
+
         if noPlace:
             pc = Constraints()
             pcc = Constraints()
@@ -955,7 +962,7 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
             pc = self.constraints.p(self.objectFromHandle[ih], "placement")
             pcc = self.constraints.p(self.objectFromHandle[ih], "placementComplement")
             ppc = self.constraints.p(self.objectFromHandle[ih], "prePlacement")
-        
+
         manifold = sf.manifold - pc
 
         # The different cases:
@@ -987,25 +994,25 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
 
         wStates = [sf.name]
         wStateObjects = [sf.state_obj]
-        
+
         if pregrasp:
             pregrasp_name = names[0] + "_pregrasp"
             _createWaypointState(pregrasp_name, pc + pgc + manifold)
             wStates.append(pregrasp_name)
             wStateObjects.append(self.state_objects[pregrasp_name])
-            
+
         if intersec:
             intersec_name = names[0] + "_intersec"
             _createWaypointState(intersec_name, pc + gc + manifold)
             wStates.append(intersec_name)
             wStateObjects.append(self.state_objects[intersec_name])
-            
+
         if preplace:
             preplace_name = names[0] + "_preplace"
             _createWaypointState(preplace_name, ppc + gc + manifold)
             wStates.append(preplace_name)
             wStateObjects.append(self.state_objects[preplace_name])
-        
+
         wStates.append(st.name)
         wStateObjects.append(st.state_obj)
 
@@ -1016,32 +1023,44 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
             backward_edge = self.graph.createWaypointTransition(
                 st.state_obj, sf.state_obj, names[1], nWaypoints, 1, sf.state_obj, False
             )
-            
+
             self.edge_objects[names[0]] = forward_edge
             self.edge_objects[names[1]] = backward_edge
-            
+
             forward_ls_edge = None
             backward_ls_edge = None
-            
+
             if crossedFoliation:
                 forward_ls_edge = self.graph.createWaypointTransition(
-                    sf.state_obj, st.state_obj, names[0] + "_ls", nWaypoints, 10, sf.state_obj, False
+                    sf.state_obj,
+                    st.state_obj,
+                    names[0] + "_ls",
+                    nWaypoints,
+                    10,
+                    sf.state_obj,
+                    False,
                 )
                 self.edge_objects[names[0] + "_ls"] = forward_ls_edge
-                
+
                 if not noPlace:
                     backward_ls_edge = self.graph.createWaypointTransition(
-                        st.state_obj, sf.state_obj, names[1] + "_ls", nWaypoints, 10, sf.state_obj, False
+                        st.state_obj,
+                        sf.state_obj,
+                        names[1] + "_ls",
+                        nWaypoints,
+                        10,
+                        sf.state_obj,
+                        False,
                     )
                     self.edge_objects[names[1] + "_ls"] = backward_ls_edge
-            
+
             wTransitions = []
             wTransitionObjects = []
-            
+
             for i in range(nTransitions):
                 nf = f"{names[0]}_{i}{i + 1}"
                 nb = f"{names[1]}_{i + 1}{i}"
-                
+
                 forward_trans = self.graph.createTransition(
                     wStateObjects[i], wStateObjects[i + 1], nf, -1, wStateObjects[i]
                 )
@@ -1050,105 +1069,128 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
                 )
                 self.edge_objects[nf] = forward_trans
                 self.edge_objects[nb] = backward_trans
-                
+
                 nf_ls = nf
                 nb_ls = nb
-            
+
                 if crossedFoliation:
                     if i == 0:
                         edgeName = nf_ls = nf + "_ls"
-                        containingState = sf.state_obj  # containing state is always start state
+                        containingState = (
+                            sf.state_obj
+                        )  # containing state is always start state
                         level_set_edge_forward = self.graph.createLevelSetTransition(
-                            wStateObjects[i], wStateObjects[i + 1], edgeName, -1, containingState
+                            wStateObjects[i],
+                            wStateObjects[i + 1],
+                            edgeName,
+                            -1,
+                            containingState,
                         )
                         self.edge_objects[edgeName] = level_set_edge_forward
-                        
+
                         paramNC_constraints = self._get_constraint_objects(
                             (st.foliation - sf.foliation).numConstraints
                         )
                         condNC_constraints = self._get_constraint_objects(
                             (st.manifold - sf.manifold).numConstraints
                         )
-                        
+
                         self.graph.addLevelSetFoliation(
-                            level_set_edge_forward, condNC_constraints, paramNC_constraints
+                            level_set_edge_forward,
+                            condNC_constraints,
+                            paramNC_constraints,
                         )
-                        self._add_constraints_to_transition(level_set_edge_forward, sf.foliation)
-                    
+                        self._add_constraints_to_transition(
+                            level_set_edge_forward, sf.foliation
+                        )
+
                     if i == nTransitions - 1 and crossedFoliation:
                         edgeName = nb_ls = nb + "_ls"
                         # containing state is goal state if an object in placement is grasped, start state otherwise
                         if not noPlace:
                             containingState = st.state_obj
-                            level_set_edge_backward = self.graph.createLevelSetTransition(
-                                wStateObjects[i + 1], wStateObjects[i], edgeName, -1, containingState
+                            level_set_edge_backward = (
+                                self.graph.createLevelSetTransition(
+                                    wStateObjects[i + 1],
+                                    wStateObjects[i],
+                                    edgeName,
+                                    -1,
+                                    containingState,
+                                )
                             )
                             self.edge_objects[edgeName] = level_set_edge_backward
-                            
+
                             pNC_constraints = self._get_constraint_objects(
                                 (sf.foliation - st.foliation).numConstraints
                             )
                             cNC_constraints = self._get_constraint_objects(
                                 sf.manifold.numConstraints
                             )
-                            
+
                             self.graph.addLevelSetFoliation(
-                                level_set_edge_backward, cNC_constraints, pNC_constraints
+                                level_set_edge_backward,
+                                cNC_constraints,
+                                pNC_constraints,
                             )
-                            self._add_constraints_to_transition(level_set_edge_backward, st.foliation)
-                    
+                            self._add_constraints_to_transition(
+                                level_set_edge_backward, st.foliation
+                            )
+
                     if forward_ls_edge:
-                        edge_to_use_forward = self.edge_objects[nf_ls] if i == 0 else forward_trans
+                        edge_to_use_forward = (
+                            self.edge_objects[nf_ls] if i == 0 else forward_trans
+                        )
                         self.graph.setWaypoint(
                             forward_ls_edge,
                             i,
                             edge_to_use_forward,
-                            wStateObjects[i + 1]
+                            wStateObjects[i + 1],
                         )
 
                     if backward_ls_edge and not noPlace:
-                        edge_to_use_backward = self.edge_objects[nb_ls] if i == nTransitions - 1 else backward_trans
+                        edge_to_use_backward = (
+                            self.edge_objects[nb_ls]
+                            if i == nTransitions - 1
+                            else backward_trans
+                        )
                         self.graph.setWaypoint(
                             backward_ls_edge,
                             nTransitions - 1 - i,
                             edge_to_use_backward,
-                            wStateObjects[i]
+                            wStateObjects[i],
                         )
 
                 # Set waypoints for regular edges
                 self.graph.setWaypoint(
-                    forward_edge,
-                    i,
-                    forward_trans,
-                    wStateObjects[i + 1]
+                    forward_edge, i, forward_trans, wStateObjects[i + 1]
                 )
                 self.graph.setWaypoint(
                     backward_edge,
                     nTransitions - 1 - i,
                     backward_trans,
-                    wStateObjects[i]
+                    wStateObjects[i],
                 )
 
                 wTransitions.append((nf, nb))
                 wTransitionObjects.append((forward_trans, backward_trans))
 
             M = 0 if gc.empty() else 1 + pregrasp
-            
+
             for i in range(M):
                 forward_trans, backward_trans = wTransitionObjects[i]
-                
+
                 self.graph.setContainingNode(forward_trans, sf.state_obj)
                 self._add_constraints_to_transition(forward_trans, sf.foliation)
-                
+
                 self.graph.setContainingNode(backward_trans, sf.state_obj)
                 self._add_constraints_to_transition(backward_trans, sf.foliation)
-            
+
             for i in range(M, nTransitions):
                 forward_trans, backward_trans = wTransitionObjects[i]
-                
+
                 self.graph.setContainingNode(forward_trans, st.state_obj)
                 self._add_constraints_to_transition(forward_trans, st.foliation)
-                
+
                 self.graph.setContainingNode(backward_trans, st.state_obj)
                 self._add_constraints_to_transition(backward_trans, st.foliation)
 
@@ -1156,19 +1198,19 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
                 forward_trans, backward_trans = wTransitionObjects[1]
                 self._add_constraints_to_transition(forward_trans, gcc)
                 self._add_constraints_to_transition(backward_trans, gcc)
-            
+
             if intersec and preplace and self.preplaceGuide:
                 forward_trans, backward_trans = wTransitionObjects[pregrasp + intersec]
                 self._add_constraints_to_transition(forward_trans, pcc)
                 self._add_constraints_to_transition(backward_trans, pcc)
-            
+
             for i in range(nTransitions - 1):
                 forward_trans, backward_trans = wTransitionObjects[i + 1]
                 self.graph.setShort(forward_trans, True)
-                
+
                 forward_trans_back, backward_trans_back = wTransitionObjects[i]
                 self.graph.setShort(backward_trans_back, True)
-        
+
         else:
             raise NotImplementedError("This case has not been implemented")
 
@@ -1214,36 +1256,36 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
     def _add_constraints_to_state(self, state_obj, constraints):
         """Convert Constraints object to constraint objects and add to state"""
         constraint_objects = []
-        
+
         for constraint_name in constraints.numConstraints:
             if constraint_name in self.constraints.available_constraints:
                 constraint_obj = self.constraints.available_constraints[constraint_name]
                 constraint_objects.append(constraint_obj)
-        
-        # Handle grasps 
+
+        # Handle grasps
         for grasp_name in constraints.grasps:
             if grasp_name in self.constraints.available_constraints:
                 constraint_obj = self.constraints.available_constraints[grasp_name]
                 constraint_objects.append(constraint_obj)
-        
+
         # Handle pregrasps
         for pregrasp_name in constraints.pregrasps:
             if pregrasp_name in self.constraints.available_constraints:
                 constraint_obj = self.constraints.available_constraints[pregrasp_name]
                 constraint_objects.append(constraint_obj)
-        
+
         if constraint_objects:
             self.graph.addNumericalConstraintsToState(state_obj, constraint_objects)
 
     def _add_constraints_to_transition(self, edge_obj, constraints):
         """Convert Constraints object to constraint objects and add to transition"""
         constraint_objects = []
-        
+
         for constraint_name in constraints.numConstraints:
             if constraint_name in self.constraints.available_constraints:
                 constraint_obj = self.constraints.available_constraints[constraint_name]
                 constraint_objects.append(constraint_obj)
-        
+
         if constraint_objects:
             self.graph.addNumericalConstraintsToTransition(edge_obj, constraint_objects)
 
@@ -1254,8 +1296,6 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
             if name in self.constraints.available_constraints:
                 constraint_objects.append(self.constraints.available_constraints[name])
         return constraint_objects
-
-
 
 
 class Rule:

--- a/src/pyhpp/manipulation/device.cc
+++ b/src/pyhpp/manipulation/device.cc
@@ -78,6 +78,11 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existFrame_overload, Model::existFrame,
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(addJointFrame_overload,
                                        Model::addJointFrame, 1, 2)
 
+PinDevicePtr_t Device::asPinDevice() {
+  hpp::pinocchio::DevicePtr_t pinDevice = std::dynamic_pointer_cast<hpp::pinocchio::Device>(obj);
+  return pinDevice;
+}
+
 bool Device_currentConfiguration(Device& d, const Configuration_t& c) {
   return d.currentConfiguration(c);
 }
@@ -182,7 +187,8 @@ void exposeDevice() {
       .def("updateGeometryPlacements", &Device::updateGeometryPlacements)
       .def("setRobotRootPosition", &Device::setRobotRootPosition)
       .def("handles", &getDeviceHandles)
-      .def("grippers", &getDeviceGrippers);
+      .def("grippers", &getDeviceGrippers)
+      .def("asPinDevice", &Device::asPinDevice);
 }
 }  // namespace manipulation
 }  // namespace pyhpp

--- a/src/pyhpp/manipulation/device.cc
+++ b/src/pyhpp/manipulation/device.cc
@@ -79,36 +79,38 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(addJointFrame_overload,
                                        Model::addJointFrame, 1, 2)
 
 PinDevicePtr_t Device::asPinDevice() {
-  hpp::pinocchio::DevicePtr_t pinDevice = std::dynamic_pointer_cast<hpp::pinocchio::Device>(obj);
+  hpp::pinocchio::DevicePtr_t pinDevice =
+      std::dynamic_pointer_cast<hpp::pinocchio::Device>(obj);
   return pinDevice;
 }
 
-void Device::setJointBounds(const char* jointName, boost::python::list py_jointBounds) {
-    Frame frame = obj->getFrameByName(jointName);
-    JointPtr_t joint = frame.joint();
-    auto jointBounds = extract_vector<value_type>(py_jointBounds);
-    
-    static const value_type inf = std::numeric_limits<value_type>::infinity();
-    
-    if (jointBounds.size() % 2 == 1) {
-        throw std::logic_error("Expect a vector of even size");
+void Device::setJointBounds(const char* jointName,
+                            boost::python::list py_jointBounds) {
+  Frame frame = obj->getFrameByName(jointName);
+  JointPtr_t joint = frame.joint();
+  auto jointBounds = extract_vector<value_type>(py_jointBounds);
+
+  static const value_type inf = std::numeric_limits<value_type>::infinity();
+
+  if (jointBounds.size() % 2 == 1) {
+    throw std::logic_error("Expect a vector of even size");
+  }
+
+  std::size_t numDofPairs = jointBounds.size() / 2;
+
+  for (std::size_t i = 0; i < numDofPairs; i++) {
+    value_type vMin = jointBounds[2 * i];
+    value_type vMax = jointBounds[2 * i + 1];
+
+    if (vMin > vMax) {
+      vMin = -inf;
+      vMax = inf;
     }
-    
-    std::size_t numDofPairs = jointBounds.size() / 2;
-    
-    for (std::size_t i = 0; i < numDofPairs; i++) {
-        value_type vMin = jointBounds[2 * i];
-        value_type vMax = jointBounds[2 * i + 1];
-        
-        if (vMin > vMax) {
-            vMin = -inf;
-            vMax = inf;
-        }
-        
-        // Set bounds for individual DOF using the old API
-        joint->lowerBound(i, vMin);  // Set lower bound for DOF i
-        joint->upperBound(i, vMax);  // Set upper bound for DOF i
-    }
+
+    // Set bounds for individual DOF using the old API
+    joint->lowerBound(i, vMin);  // Set lower bound for DOF i
+    joint->upperBound(i, vMax);  // Set upper bound for DOF i
+  }
 }
 boost::python::list Device::getJointConfig(const char* jointName) {
   try {
@@ -245,8 +247,7 @@ void exposeDevice() {
       .def("asPinDevice", &Device::asPinDevice)
       .def("getJointNames", &Device::getJointNames)
       .def("getJointConfig", &Device::getJointConfig)
-      .def("setJointBounds", &Device::setJointBounds)
-      ;
+      .def("setJointBounds", &Device::setJointBounds);
 }
 }  // namespace manipulation
 }  // namespace pyhpp

--- a/src/pyhpp/manipulation/device.cc
+++ b/src/pyhpp/manipulation/device.cc
@@ -83,6 +83,59 @@ PinDevicePtr_t Device::asPinDevice() {
   return pinDevice;
 }
 
+void Device::setJointBounds(const char* jointName, boost::python::list py_jointBounds) {
+    Frame frame = obj->getFrameByName(jointName);
+    JointPtr_t joint = frame.joint();
+    auto jointBounds = extract_vector<value_type>(py_jointBounds);
+    
+    static const value_type inf = std::numeric_limits<value_type>::infinity();
+    
+    if (jointBounds.size() % 2 == 1) {
+        throw std::logic_error("Expect a vector of even size");
+    }
+    
+    std::size_t numDofPairs = jointBounds.size() / 2;
+    
+    for (std::size_t i = 0; i < numDofPairs; i++) {
+        value_type vMin = jointBounds[2 * i];
+        value_type vMax = jointBounds[2 * i + 1];
+        
+        if (vMin > vMax) {
+            vMin = -inf;
+            vMax = inf;
+        }
+        
+        // Set bounds for individual DOF using the old API
+        joint->lowerBound(i, vMin);  // Set lower bound for DOF i
+        joint->upperBound(i, vMax);  // Set upper bound for DOF i
+    }
+}
+boost::python::list Device::getJointConfig(const char* jointName) {
+  try {
+    Frame frame = obj->getFrameByName(jointName);
+    if (frame.isFixed()) return boost::python::list();
+    JointPtr_t joint = frame.joint();
+    if (!joint) return boost::python::list();
+    hpp::core::vector_t config = obj->currentConfiguration();
+    size_type ric = joint->rankInConfiguration();
+    size_type dim = joint->configSize();
+    auto segment = config.segment(ric, dim);
+    std::vector<double> vec(segment.data(), segment.data() + segment.size());
+    return to_python_list(vec);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+boost::python::list Device::getJointNames() {
+  try {
+    const Model& model = obj->model();
+    return to_python_list(model.names);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
 bool Device_currentConfiguration(Device& d, const Configuration_t& c) {
   return d.currentConfiguration(c);
 }
@@ -152,6 +205,7 @@ void exposeHandle() {
           static_cast<value_type (Handle::*)() const>(&Handle::clearance),
           static_cast<void (Handle::*)(const value_type&)>(&Handle::clearance))
       .def("createGrasp", &Handle::createGrasp)
+      .def("createPreGrasp", &Handle::createPreGrasp)
       .def("createGraspComplement", &Handle::createGraspComplement)
       .def("createGraspAndComplement", &Handle::createGraspAndComplement);
   class_<std::map<std::string, HandlePtr_t> >("HandleMap")
@@ -188,7 +242,11 @@ void exposeDevice() {
       .def("setRobotRootPosition", &Device::setRobotRootPosition)
       .def("handles", &getDeviceHandles)
       .def("grippers", &getDeviceGrippers)
-      .def("asPinDevice", &Device::asPinDevice);
+      .def("asPinDevice", &Device::asPinDevice)
+      .def("getJointNames", &Device::getJointNames)
+      .def("getJointConfig", &Device::getJointConfig)
+      .def("setJointBounds", &Device::setJointBounds)
+      ;
 }
 }  // namespace manipulation
 }  // namespace pyhpp

--- a/src/pyhpp/manipulation/device.hh
+++ b/src/pyhpp/manipulation/device.hh
@@ -30,9 +30,9 @@
 #include <hpp/constraints/implicit.hh>
 #include <hpp/manipulation/device.hh>
 #include <hpp/manipulation/handle.hh>
-#include <hpp/pinocchio/gripper.hh>
 #include <hpp/pinocchio/device.hh>
 #include <hpp/pinocchio/frame.hh>
+#include <hpp/pinocchio/gripper.hh>
 #include <hpp/pinocchio/joint.hh>
 #include <pinocchio/multibody/data.hpp>
 #include <pinocchio/multibody/geometry.hpp>

--- a/src/pyhpp/manipulation/device.hh
+++ b/src/pyhpp/manipulation/device.hh
@@ -32,6 +32,8 @@
 #include <hpp/manipulation/handle.hh>
 #include <hpp/pinocchio/gripper.hh>
 #include <hpp/pinocchio/device.hh>
+#include <hpp/pinocchio/frame.hh>
+#include <hpp/pinocchio/joint.hh>
 #include <pinocchio/multibody/data.hpp>
 #include <pinocchio/multibody/geometry.hpp>
 #include <pinocchio/spatial/se3.hpp>
@@ -58,6 +60,9 @@ typedef hpp::manipulation::HandlePtr_t HandlePtr_t;
 typedef hpp::manipulation::Handle Handle;
 typedef hpp::manipulation::DevicePtr_t DevicePtr_t;
 typedef hpp::pinocchio::DevicePtr_t PinDevicePtr_t;
+typedef hpp::pinocchio::Frame Frame;
+typedef hpp::pinocchio::Joint Joint;
+typedef hpp::pinocchio::JointPtr_t JointPtr_t;
 
 // Wrapper class to hpp::manipulation::Device
 //
@@ -86,6 +91,9 @@ struct Device {
   void setRobotRootPosition(const std::string& robotName,
                             const Transform3s& positionWRTParentJoint);
   PinDevicePtr_t asPinDevice();
+  boost::python::list getJointConfig(const char* jointName);
+  boost::python::list getJointNames();
+  void setJointBounds(const char* jointName, boost::python::list jointBounds);
 };  // struct Device
 }  // namespace manipulation
 }  // namespace pyhpp

--- a/src/pyhpp/manipulation/device.hh
+++ b/src/pyhpp/manipulation/device.hh
@@ -31,9 +31,11 @@
 #include <hpp/manipulation/device.hh>
 #include <hpp/manipulation/handle.hh>
 #include <hpp/pinocchio/gripper.hh>
+#include <hpp/pinocchio/device.hh>
 #include <pinocchio/multibody/data.hpp>
 #include <pinocchio/multibody/geometry.hpp>
 #include <pinocchio/spatial/se3.hpp>
+#include <pyhpp/manipulation/fwd.hh>
 
 namespace pyhpp {
 namespace manipulation {
@@ -54,6 +56,8 @@ typedef hpp::pinocchio::Gripper Gripper;
 typedef hpp::pinocchio::Computation_t Computation_t;
 typedef hpp::manipulation::HandlePtr_t HandlePtr_t;
 typedef hpp::manipulation::Handle Handle;
+typedef hpp::manipulation::DevicePtr_t DevicePtr_t;
+typedef hpp::pinocchio::DevicePtr_t PinDevicePtr_t;
 
 // Wrapper class to hpp::manipulation::Device
 //
@@ -61,8 +65,8 @@ typedef hpp::manipulation::Handle Handle;
 // limitation, we create a wrapper class and bind this class with boost python
 // instead of the original class.
 struct Device {
-  hpp::manipulation::DevicePtr_t obj;
-  Device(const hpp::manipulation::DevicePtr_t& object);
+  DevicePtr_t obj;
+  Device(const DevicePtr_t& object);
   Device(const std::string& name);
   // Methods from hpp::pinocchio::Device
   const std::string& name() const;
@@ -81,6 +85,7 @@ struct Device {
   // Methods for hpp::manipulation::Device
   void setRobotRootPosition(const std::string& robotName,
                             const Transform3s& positionWRTParentJoint);
+  PinDevicePtr_t asPinDevice();
 };  // struct Device
 }  // namespace manipulation
 }  // namespace pyhpp

--- a/src/pyhpp/manipulation/graph.cc
+++ b/src/pyhpp/manipulation/graph.cc
@@ -40,6 +40,158 @@
 #include <hpp/manipulation/steering-method/graph.hh>
 #include <pinocchio/spatial/se3.hpp>
 
+namespace {
+
+    const char* DOC_CREATESTATE = 
+        "Create one or several states. "
+        "The order is important - the first should be the most restrictive one as a configuration "
+        "will be in the first state for which the constraints are satisfied.";
+
+    const char* DOC_CREATETRANSITION = 
+        "Create a transition. "
+        "The weights define the probability of selecting a transition among all the "
+        "outgoing transitions of a state. The probability of a transition is "
+        "w_i / sum(w_j), where each w_j corresponds to an outgoing transition from a given state. "
+        "To have a transition that cannot be selected by the M-RRT algorithm but is still "
+        "acceptable, set its weight to zero.";
+
+    const char* DOC_SETCONTAININGNODE = 
+        "Set in which state a transition is. "
+        "Paths satisfying the transition constraints satisfy the state constraints.";
+
+    const char* DOC_GETCONTAININGNODE = 
+        "Get the name of the state in which a transition is. "
+        "Paths satisfying the transition constraints satisfy the state constraints.";
+
+    const char* DOC_SETSHORT = 
+        "Set that a transition is short. "
+        "When a transition is tagged as short, extension along this transition is "
+        "done differently in RRT-like algorithms. Instead of projecting "
+        "a random configuration in the destination state, the "
+        "configuration to extend itself is projected in the destination "
+        "state. This makes the rate of success higher.";
+
+    const char* DOC_ISSHORT = 
+        "Check if a transition is short.";
+
+    const char* DOC_CREATEWAYPOINTTRANSITION = 
+        "Create a WaypointTransition. "
+        "See documentation of class hpp::manipulation::graph::WaypointEdge "
+        "for more information.";
+
+    const char* DOC_CREATELEVELSETTRANSITION = 
+        "Create a LevelSetTransition. "
+        "See documentation of class hpp::manipulation::graph::LevelSetEdge "
+        "for more information.";
+
+    const char* DOC_GETNODESCONNECTEDBYTRANSITION = 
+        "Get the names of the states connected by a transition.";
+
+    const char* DOC_GETWEIGHT = 
+        "Get weight of a transition.";
+
+    const char* DOC_SETWEIGHT = 
+        "Set weight of a transition. "
+        "You cannot set weight for waypoint transitions.";
+
+    const char* DOC_GETSTATE = 
+        "Get the name of the state corresponding to the configuration.";
+
+    const char* DOC_ADDNUMERICALCONSTRAINT = 
+        "Add a numerical constraint to a state.";
+
+    const char* DOC_ADDNUMERICALCONSTRAINTS = 
+        "Add numerical constraints to a state.";
+
+    const char* DOC_ADDNUMERICALCONSTRAINTSFORPATH = 
+        "Add numerical constraints for path to a state.";
+
+    const char* DOC_GETNUMERICALCONSTRAINTS = 
+        "Get numerical constraints of a state.";
+
+    const char* DOC_RESETCONSTRAINTS = 
+        "Reset constraints of a state.";
+
+    const char* DOC_REGISTERCONSTRAINTS = 
+        "Register constraints in the graph.";
+
+    const char* DOC_GETCONFIGERRORFORSTATE = 
+        "Get error of a config with respect to a state constraint. "
+        "Returns whether the configuration belongs to the state. "
+        "Calls core::ConstraintSet::isSatisfied for the state constraints.";
+
+    const char* DOC_GETCONFIGERRORFORTRANSITION = 
+        "Get error of a config with respect to a transition constraint. "
+        "Returns whether the configuration belongs to the transition. "
+        "Calls core::ConfigProjector::rightHandSideFromConfig with "
+        "the input configuration and then core::ConstraintSet::isSatisfied "
+        "on the transition constraints.";
+
+    const char* DOC_GETCONFIGERRORFORTRANSITIONLEAF = 
+        "Get error of a config with respect to a transition foliation leaf. "
+        "Returns whether config can be the end point of a path of the transition "
+        "starting at leafConfig.";
+
+    const char* DOC_GETCONFIGERRORFORTRANSITIONTARGET = 
+        "Get error of a config with respect to the target of a transition foliation leaf. "
+        "Returns whether config can be the end point of a path of the transition "
+        "starting at leafConfig.";
+
+    const char* DOC_APPLYSTATECONSTRAINTS = 
+        "Apply constraints to a configuration. "
+        "Returns ConstraintResult with success flag, output configuration, and error norm.";
+
+    const char* DOC_APPLYLEAFCONSTRAINTS = 
+        "Apply transition constraints to a configuration. "
+        "Returns ConstraintResult with success flag, output configuration, and error norm. "
+        "If success, the output configuration is reachable from q_rhs along the transition.";
+
+    const char* DOC_GENERATETARGETCONFIG = 
+        "Generate configuration in destination state on a given leaf. "
+        "Returns ConstraintResult with success flag, output configuration, and error norm. "
+        "Computes a configuration in the destination state of the transition, "
+        "reachable from q_rhs.";
+
+    const char* DOC_ADDLEVELSETFOLIATION = 
+        "Add the numerical constraints to a LevelSetTransition that create the foliation.";
+
+    const char* DOC_GETSECURITYMARGINMATRIXFORTRANSITION = 
+        "Get security margin matrix for a transition as list of lists.";
+
+    const char* DOC_SETSECURITYMARGINFORTRANSITION = 
+        "Set collision security margin for a pair of joints along a transition.";
+
+    const char* DOC_GETRELATIVEMOTIONMATRIX = 
+        "Get relative motion matrix for a transition as list of lists.";
+
+    const char* DOC_REMOVECOLLISIONPAIRFROMTRANSITION = 
+        "Remove collision pairs from a transition.";
+
+    const char* DOC_CREATESUBGRAPH = 
+        "Create a subgraph with guided state selection.";
+
+    const char* DOC_SETTARGETNODELIST = 
+        "Set the target state list for guided state selection.";
+
+    const char* DOC_DISPLAYSTATECONSTRAINTS = 
+        "Print set of constraints relative to a state in a string.";
+
+    const char* DOC_DISPLAYTRANSITIONCONSTRAINTS = 
+        "Print set of constraints relative to a transition in a string.";
+
+    const char* DOC_DISPLAYTRANSITIONTARGETCONSTRAINTS = 
+        "Print set of constraints relative to a transition in a string.";
+
+    const char* DOC_DISPLAY = 
+        "Display the current graph. "
+        "The graph is printed in DOT format.";
+
+    const char* DOC_INITIALIZE = 
+        "Initialize the graph. "
+        "Performs final initialization of the constraint graph.";
+
+}
+
 namespace pyhpp {
 namespace manipulation {
 
@@ -614,70 +766,70 @@ void exposeGraph() {
   class_<PyWEdge, PyWEdgePtr_t>("Transition", no_init);
 
   class_<PyWGraph>("Graph", init<const std::string&, const PyWDevicePtr_t&,
-                                 const PyWProblemPtr_t&>())
+                                const PyWProblemPtr_t&>())
 
       // Configuration methods
       .PYHPP_DEFINE_GETTER_SETTER(PyWGraph, maxIterations, hpp::manipulation::size_type)
       .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(PyWGraph, errorThreshold, hpp::manipulation::value_type)
 
       // Graph construction
-      .PYHPP_DEFINE_METHOD(PyWGraph, createState)
-      .PYHPP_DEFINE_METHOD(PyWGraph, createTransition)
-      .PYHPP_DEFINE_METHOD(PyWGraph, createWaypointTransition)
-      .PYHPP_DEFINE_METHOD(PyWGraph, createLevelSetTransition)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, createState, DOC_CREATESTATE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, createTransition, DOC_CREATETRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, createWaypointTransition, DOC_CREATEWAYPOINTTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, createLevelSetTransition, DOC_CREATELEVELSETTRANSITION)
 
       // Transition/State management
-      .PYHPP_DEFINE_METHOD(PyWGraph, setContainingNode)
-      .PYHPP_DEFINE_METHOD(PyWGraph, getContainingNode)
-      .PYHPP_DEFINE_METHOD(PyWGraph, setShort)
-      .PYHPP_DEFINE_METHOD(PyWGraph, isShort)
-      .PYHPP_DEFINE_METHOD(PyWGraph, getNodesConnectedByTransition)
-      .PYHPP_DEFINE_METHOD(PyWGraph, setWeight)
-      .PYHPP_DEFINE_METHOD(PyWGraph, getWeight)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, setContainingNode, DOC_SETCONTAININGNODE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getContainingNode, DOC_GETCONTAININGNODE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, setShort, DOC_SETSHORT)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, isShort, DOC_ISSHORT)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getNodesConnectedByTransition, DOC_GETNODESCONNECTEDBYTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, setWeight, DOC_SETWEIGHT)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getWeight, DOC_GETWEIGHT)
 
       // State queries
-      .PYHPP_DEFINE_METHOD(PyWGraph, getState)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getState, DOC_GETSTATE)
 
       // Constraint management
-      .PYHPP_DEFINE_METHOD(PyWGraph, addNumericalConstraint)
-      .PYHPP_DEFINE_METHOD(PyWGraph, addNumericalConstraints)
-      .PYHPP_DEFINE_METHOD(PyWGraph, addNumericalConstraintsForPath)
-      .PYHPP_DEFINE_METHOD(PyWGraph, getNumericalConstraints)
-      .PYHPP_DEFINE_METHOD(PyWGraph, resetConstraints)
-      .PYHPP_DEFINE_METHOD(PyWGraph, registerConstraints)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraint, DOC_ADDNUMERICALCONSTRAINT)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraints, DOC_ADDNUMERICALCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraintsForPath, DOC_ADDNUMERICALCONSTRAINTSFORPATH)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraints, DOC_GETNUMERICALCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, resetConstraints, DOC_RESETCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, registerConstraints, DOC_REGISTERCONSTRAINTS)
 
       // Configuration error checking
-      .PYHPP_DEFINE_METHOD(PyWGraph, getConfigErrorForState)
-      .PYHPP_DEFINE_METHOD(PyWGraph, getConfigErrorForTransition)
-      .PYHPP_DEFINE_METHOD(PyWGraph, getConfigErrorForTransitionLeaf)
-      .PYHPP_DEFINE_METHOD(PyWGraph, getConfigErrorForTransitionTarget)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForState, DOC_GETCONFIGERRORFORSTATE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForTransition, DOC_GETCONFIGERRORFORTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForTransitionLeaf, DOC_GETCONFIGERRORFORTRANSITIONLEAF)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForTransitionTarget, DOC_GETCONFIGERRORFORTRANSITIONTARGET)
 
       // Constraint application
-      .PYHPP_DEFINE_METHOD(PyWGraph, applyStateConstraints)
-      .PYHPP_DEFINE_METHOD(PyWGraph, applyLeafConstraints)
-      .PYHPP_DEFINE_METHOD(PyWGraph, generateTargetConfig)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, applyStateConstraints, DOC_APPLYSTATECONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, applyLeafConstraints, DOC_APPLYLEAFCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, generateTargetConfig, DOC_GENERATETARGETCONFIG)
 
-      // Level set edges
-      .PYHPP_DEFINE_METHOD(PyWGraph, addLevelSetFoliation)
+      // Level set transitions
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addLevelSetFoliation, DOC_ADDLEVELSETFOLIATION)
 
       // Security margins and collision
-      .PYHPP_DEFINE_METHOD(PyWGraph, getSecurityMarginMatrixForTransition)
-      .PYHPP_DEFINE_METHOD(PyWGraph, setSecurityMarginForTransition)
-      .PYHPP_DEFINE_METHOD(PyWGraph, getRelativeMotionMatrix)
-      .PYHPP_DEFINE_METHOD(PyWGraph, removeCollisionPairFromTransition)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getSecurityMarginMatrixForTransition, DOC_GETSECURITYMARGINMATRIXFORTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, setSecurityMarginForTransition, DOC_SETSECURITYMARGINFORTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getRelativeMotionMatrix, DOC_GETRELATIVEMOTIONMATRIX)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, removeCollisionPairFromTransition, DOC_REMOVECOLLISIONPAIRFROMTRANSITION)
 
       // Subgraph management
-      .PYHPP_DEFINE_METHOD(PyWGraph, createSubGraph)
-      .PYHPP_DEFINE_METHOD(PyWGraph, setTargetNodeList)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, createSubGraph, DOC_CREATESUBGRAPH)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, setTargetNodeList, DOC_SETTARGETNODELIST)
 
       // Display and debugging
-      .PYHPP_DEFINE_METHOD(PyWGraph, displayStateConstraints)
-      .PYHPP_DEFINE_METHOD(PyWGraph, displayTransitionConstraints)
-      .PYHPP_DEFINE_METHOD(PyWGraph, displayTransitionTargetConstraints)
-      .PYHPP_DEFINE_METHOD(PyWGraph, display)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, displayStateConstraints, DOC_DISPLAYSTATECONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, displayTransitionConstraints, DOC_DISPLAYTRANSITIONCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, displayTransitionTargetConstraints, DOC_DISPLAYTRANSITIONTARGETCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, display, DOC_DISPLAY)
 
       // Initialization
-      .PYHPP_DEFINE_METHOD(PyWGraph, initialize);
+      .PYHPP_DEFINE_METHOD1(PyWGraph, initialize, DOC_INITIALIZE);
 
   class_<ConstraintResult>("ConstraintResult")
       .def_readwrite("success", &ConstraintResult::success)

--- a/src/pyhpp/manipulation/graph.cc
+++ b/src/pyhpp/manipulation/graph.cc
@@ -30,8 +30,10 @@
 #include <../src/pyhpp/manipulation/device.hh>
 #include <../src/pyhpp/manipulation/graph.hh>
 #include <../src/pyhpp/manipulation/problem.hh>
-
 #include <boost/python.hpp>
+#include <hpp/constraints/convex-shape-contact.hh>
+#include <hpp/constraints/differentiable-function.hh>
+#include <hpp/constraints/explicit/convex-shape-contact.hh>
 #include <hpp/manipulation/graph/edge.hh>
 #include <hpp/manipulation/graph/graph.hh>
 #include <hpp/manipulation/graph/guided-state-selector.hh>
@@ -39,180 +41,186 @@
 #include <hpp/manipulation/graph/state.hh>
 #include <hpp/manipulation/steering-method/graph.hh>
 #include <pinocchio/spatial/se3.hpp>
-#include <hpp/constraints/differentiable-function.hh>
-#include <hpp/constraints/convex-shape-contact.hh>
-#include <hpp/constraints/explicit/convex-shape-contact.hh>
 namespace {
 
-    const char* DOC_CREATESTATE = 
-        "Create one or several states. "
-        "The order is important - the first should be the most restrictive one as a configuration "
-        "will be in the first state for which the constraints are satisfied.";
+const char* DOC_CREATESTATE =
+    "Create one or several states. "
+    "The order is important - the first should be the most restrictive one as "
+    "a configuration "
+    "will be in the first state for which the constraints are satisfied.";
 
-    const char* DOC_CREATETRANSITION = 
-        "Create a transition. "
-        "The weights define the probability of selecting a transition among all the "
-        "outgoing transitions of a state. The probability of a transition is "
-        "w_i / sum(w_j), where each w_j corresponds to an outgoing transition from a given state. "
-        "To have a transition that cannot be selected by the M-RRT algorithm but is still "
-        "acceptable, set its weight to zero.";
+const char* DOC_CREATETRANSITION =
+    "Create a transition. "
+    "The weights define the probability of selecting a transition among all "
+    "the "
+    "outgoing transitions of a state. The probability of a transition is "
+    "w_i / sum(w_j), where each w_j corresponds to an outgoing transition from "
+    "a given state. "
+    "To have a transition that cannot be selected by the M-RRT algorithm but "
+    "is still "
+    "acceptable, set its weight to zero.";
 
-    const char* DOC_SETCONTAININGNODE = 
-        "Set in which state a transition is. "
-        "Paths satisfying the transition constraints satisfy the state constraints.";
+const char* DOC_SETCONTAININGNODE =
+    "Set in which state a transition is. "
+    "Paths satisfying the transition constraints satisfy the state "
+    "constraints.";
 
-    const char* DOC_GETCONTAININGNODE = 
-        "Get the name of the state in which a transition is. "
-        "Paths satisfying the transition constraints satisfy the state constraints.";
+const char* DOC_GETCONTAININGNODE =
+    "Get the name of the state in which a transition is. "
+    "Paths satisfying the transition constraints satisfy the state "
+    "constraints.";
 
-    const char* DOC_SETSHORT = 
-        "Set that a transition is short. "
-        "When a transition is tagged as short, extension along this transition is "
-        "done differently in RRT-like algorithms. Instead of projecting "
-        "a random configuration in the destination state, the "
-        "configuration to extend itself is projected in the destination "
-        "state. This makes the rate of success higher.";
+const char* DOC_SETSHORT =
+    "Set that a transition is short. "
+    "When a transition is tagged as short, extension along this transition is "
+    "done differently in RRT-like algorithms. Instead of projecting "
+    "a random configuration in the destination state, the "
+    "configuration to extend itself is projected in the destination "
+    "state. This makes the rate of success higher.";
 
-    const char* DOC_ISSHORT = 
-        "Check if a transition is short.";
+const char* DOC_ISSHORT = "Check if a transition is short.";
 
-    const char* DOC_CREATEWAYPOINTTRANSITION = 
-        "Create a WaypointTransition. "
-        "See documentation of class hpp::manipulation::graph::WaypointEdge "
-        "for more information.";
+const char* DOC_CREATEWAYPOINTTRANSITION =
+    "Create a WaypointTransition. "
+    "See documentation of class hpp::manipulation::graph::WaypointEdge "
+    "for more information.";
 
-    const char* DOC_CREATELEVELSETTRANSITION = 
-        "Create a LevelSetTransition. "
-        "See documentation of class hpp::manipulation::graph::LevelSetEdge "
-        "for more information.";
+const char* DOC_CREATELEVELSETTRANSITION =
+    "Create a LevelSetTransition. "
+    "See documentation of class hpp::manipulation::graph::LevelSetEdge "
+    "for more information.";
 
-    const char* DOC_GETNODESCONNECTEDBYTRANSITION = 
-        "Get the names of the states connected by a transition.";
+const char* DOC_GETNODESCONNECTEDBYTRANSITION =
+    "Get the names of the states connected by a transition.";
 
-    const char* DOC_GETWEIGHT = 
-        "Get weight of a transition.";
+const char* DOC_GETWEIGHT = "Get weight of a transition.";
 
-    const char* DOC_SETWEIGHT = 
-        "Set weight of a transition. "
-        "You cannot set weight for waypoint transitions.";
+const char* DOC_SETWEIGHT =
+    "Set weight of a transition. "
+    "You cannot set weight for waypoint transitions.";
 
-    const char* DOC_GETSTATE = 
-        "Get the name of the state corresponding to the configuration.";
+const char* DOC_GETSTATE =
+    "Get the name of the state corresponding to the configuration.";
 
-    const char* DOC_ADDNUMERICALCONSTRAINT = 
-        "Add a numerical constraint to a state.";
+const char* DOC_ADDNUMERICALCONSTRAINT =
+    "Add a numerical constraint to a state.";
 
-    const char* DOC_ADDNUMERICALCONSTRAINTSTOSTATE = 
-        "Add numerical constraints to a state.";
-        
-    const char* DOC_ADDNUMERICALCONSTRAINTSTOTRANSITION = 
-        "Add numerical constraints to a TRANSITION.";
+const char* DOC_ADDNUMERICALCONSTRAINTSTOSTATE =
+    "Add numerical constraints to a state.";
 
-    const char* DOC_ADDNUMERICALCONSTRAINTSFORPATH = 
-        "Add numerical constraints for path to a state.";
+const char* DOC_ADDNUMERICALCONSTRAINTSTOTRANSITION =
+    "Add numerical constraints to a TRANSITION.";
 
-    const char* DOC_GETNUMERICALCONSTRAINTSFORSTATE = 
-        "Get numerical constraints of a state.";
-    const char* DOC_GETNUMERICALCONSTRAINTSFOREDGE = 
-        "Get numerical constraints of an edge.";
-    const char* DOC_GETNUMERICALCONSTRAINTSFORGRAPH = 
-        "Get numerical constraints of the graph.";
+const char* DOC_ADDNUMERICALCONSTRAINTSFORPATH =
+    "Add numerical constraints for path to a state.";
 
-    const char* DOC_RESETCONSTRAINTS = 
-        "Reset constraints of a state.";
+const char* DOC_GETNUMERICALCONSTRAINTSFORSTATE =
+    "Get numerical constraints of a state.";
+const char* DOC_GETNUMERICALCONSTRAINTSFOREDGE =
+    "Get numerical constraints of an edge.";
+const char* DOC_GETNUMERICALCONSTRAINTSFORGRAPH =
+    "Get numerical constraints of the graph.";
 
-    const char* DOC_REGISTERCONSTRAINTS = 
-        "Register constraints in the graph.";
+const char* DOC_RESETCONSTRAINTS = "Reset constraints of a state.";
 
-    const char* DOC_GETCONFIGERRORFORSTATE = 
-        "Get error of a config with respect to a state constraint. "
-        "Returns whether the configuration belongs to the state. "
-        "Calls core::ConstraintSet::isSatisfied for the state constraints.";
+const char* DOC_REGISTERCONSTRAINTS = "Register constraints in the graph.";
 
-    const char* DOC_GETCONFIGERRORFORTRANSITION = 
-        "Get error of a config with respect to a transition constraint. "
-        "Returns whether the configuration belongs to the transition. "
-        "Calls core::ConfigProjector::rightHandSideFromConfig with "
-        "the input configuration and then core::ConstraintSet::isSatisfied "
-        "on the transition constraints.";
+const char* DOC_GETCONFIGERRORFORSTATE =
+    "Get error of a config with respect to a state constraint. "
+    "Returns whether the configuration belongs to the state. "
+    "Calls core::ConstraintSet::isSatisfied for the state constraints.";
 
-    const char* DOC_GETCONFIGERRORFORTRANSITIONLEAF = 
-        "Get error of a config with respect to a transition foliation leaf. "
-        "Returns whether config can be the end point of a path of the transition "
-        "starting at leafConfig.";
+const char* DOC_GETCONFIGERRORFORTRANSITION =
+    "Get error of a config with respect to a transition constraint. "
+    "Returns whether the configuration belongs to the transition. "
+    "Calls core::ConfigProjector::rightHandSideFromConfig with "
+    "the input configuration and then core::ConstraintSet::isSatisfied "
+    "on the transition constraints.";
 
-    const char* DOC_GETCONFIGERRORFORTRANSITIONTARGET = 
-        "Get error of a config with respect to the target of a transition foliation leaf. "
-        "Returns whether config can be the end point of a path of the transition "
-        "starting at leafConfig.";
+const char* DOC_GETCONFIGERRORFORTRANSITIONLEAF =
+    "Get error of a config with respect to a transition foliation leaf. "
+    "Returns whether config can be the end point of a path of the transition "
+    "starting at leafConfig.";
 
-    const char* DOC_APPLYSTATECONSTRAINTS = 
-        "Apply constraints to a configuration. "
-        "Returns ConstraintResult with success flag, output configuration, and error norm.";
+const char* DOC_GETCONFIGERRORFORTRANSITIONTARGET =
+    "Get error of a config with respect to the target of a transition "
+    "foliation leaf. "
+    "Returns whether config can be the end point of a path of the transition "
+    "starting at leafConfig.";
 
-    const char* DOC_APPLYLEAFCONSTRAINTS = 
-        "Apply transition constraints to a configuration. "
-        "Returns ConstraintResult with success flag, output configuration, and error norm. "
-        "If success, the output configuration is reachable from q_rhs along the transition.";
+const char* DOC_APPLYSTATECONSTRAINTS =
+    "Apply constraints to a configuration. "
+    "Returns ConstraintResult with success flag, output configuration, and "
+    "error norm.";
 
-    const char* DOC_GENERATETARGETCONFIG = 
-        "Generate configuration in destination state on a given leaf. "
-        "Returns ConstraintResult with success flag, output configuration, and error norm. "
-        "Computes a configuration in the destination state of the transition, "
-        "reachable from q_rhs.";
+const char* DOC_APPLYLEAFCONSTRAINTS =
+    "Apply transition constraints to a configuration. "
+    "Returns ConstraintResult with success flag, output configuration, and "
+    "error norm. "
+    "If success, the output configuration is reachable from q_rhs along the "
+    "transition.";
 
-    const char* DOC_ADDLEVELSETFOLIATION = 
-        "Add the numerical constraints to a LevelSetTransition that create the foliation.";
+const char* DOC_GENERATETARGETCONFIG =
+    "Generate configuration in destination state on a given leaf. "
+    "Returns ConstraintResult with success flag, output configuration, and "
+    "error norm. "
+    "Computes a configuration in the destination state of the transition, "
+    "reachable from q_rhs.";
 
-    const char* DOC_GETSECURITYMARGINMATRIXFORTRANSITION = 
-        "Get security margin matrix for a transition as list of lists.";
+const char* DOC_ADDLEVELSETFOLIATION =
+    "Add the numerical constraints to a LevelSetTransition that create the "
+    "foliation.";
 
-    const char* DOC_SETSECURITYMARGINFORTRANSITION = 
-        "Set collision security margin for a pair of joints along a transition.";
+const char* DOC_GETSECURITYMARGINMATRIXFORTRANSITION =
+    "Get security margin matrix for a transition as list of lists.";
 
-    const char* DOC_GETRELATIVEMOTIONMATRIX = 
-        "Get relative motion matrix for a transition as list of lists.";
+const char* DOC_SETSECURITYMARGINFORTRANSITION =
+    "Set collision security margin for a pair of joints along a transition.";
 
-    const char* DOC_REMOVECOLLISIONPAIRFROMTRANSITION = 
-        "Remove collision pairs from a transition.";
+const char* DOC_GETRELATIVEMOTIONMATRIX =
+    "Get relative motion matrix for a transition as list of lists.";
 
-    const char* DOC_CREATESUBGRAPH = 
-        "Create a subgraph with guided state selection.";
+const char* DOC_REMOVECOLLISIONPAIRFROMTRANSITION =
+    "Remove collision pairs from a transition.";
 
-    const char* DOC_SETTARGETNODELIST = 
-        "Set the target state list for guided state selection.";
+const char* DOC_CREATESUBGRAPH =
+    "Create a subgraph with guided state selection.";
 
-    const char* DOC_DISPLAYSTATECONSTRAINTS = 
-        "Print set of constraints relative to a state in a string.";
+const char* DOC_SETTARGETNODELIST =
+    "Set the target state list for guided state selection.";
 
-    const char* DOC_DISPLAYTRANSITIONCONSTRAINTS = 
-        "Print set of constraints relative to a transition in a string.";
+const char* DOC_DISPLAYSTATECONSTRAINTS =
+    "Print set of constraints relative to a state in a string.";
 
-    const char* DOC_DISPLAYTRANSITIONTARGETCONSTRAINTS = 
-        "Print set of constraints relative to a transition in a string.";
+const char* DOC_DISPLAYTRANSITIONCONSTRAINTS =
+    "Print set of constraints relative to a transition in a string.";
 
-    const char* DOC_DISPLAY = 
-        "Display the current graph. "
-        "The graph is printed in DOT format.";
+const char* DOC_DISPLAYTRANSITIONTARGETCONSTRAINTS =
+    "Print set of constraints relative to a transition in a string.";
 
-    const char* DOC_INITIALIZE = 
-        "Initialize the graph. "
-        "Performs final initialization of the constraint graph.";
+const char* DOC_DISPLAY =
+    "Display the current graph. "
+    "The graph is printed in DOT format.";
 
+const char* DOC_INITIALIZE =
+    "Initialize the graph. "
+    "Performs final initialization of the constraint graph.";
 
-    const char* DOC_SETWAYPOINT = 
-          "Set waypoint configuration for a waypoint transition. "
-          "Configures which edge and state to use at the specified waypoint index.";
+const char* DOC_SETWAYPOINT =
+    "Set waypoint configuration for a waypoint transition. "
+    "Configures which edge and state to use at the specified waypoint index.";
 
-    const char* DOC_CREATEPLACEMENTCONSTRAINT = 
-      "Create placement constraint between object surfaces and environment surfaces. "
-      "Creates constraints that ensure proper contact between object and environment.";
+const char* DOC_CREATEPLACEMENTCONSTRAINT =
+    "Create placement constraint between object surfaces and environment "
+    "surfaces. "
+    "Creates constraints that ensure proper contact between object and "
+    "environment.";
 
-    const char* DOC_CREATEPREPLACEMENTCONSTRAINT = 
-      "Create pre-placement constraint with specified width margin. "
-      "Used for approaching placement configurations before final placement.";
+const char* DOC_CREATEPREPLACEMENTCONSTRAINT =
+    "Create pre-placement constraint with specified width margin. "
+    "Used for approaching placement configurations before final placement.";
 
-}
+}  // namespace
 
 namespace pyhpp {
 namespace manipulation {
@@ -250,7 +258,9 @@ PyWGraph::PyWGraph(const hpp::manipulation::graph::GraphPtr_t& object)
 
 PyWGraph::PyWGraph(const std::string& name, const PyWDevicePtr_t& d,
                    const PyWProblemPtr_t& problem)
-    : obj(hpp::manipulation::graph::Graph::create(name, d->obj, problem->obj)), robot(d), problem(problem) {}
+    : obj(hpp::manipulation::graph::Graph::create(name, d->obj, problem->obj)),
+      robot(d),
+      problem(problem) {}
 
 // =============================================================================
 // Configuration methods
@@ -260,24 +270,20 @@ void PyWGraph::maxIterations(size_type iterations) {
   obj->maxIterations(iterations);
 }
 
-size_type PyWGraph::maxIterations() const {
-  return obj->maxIterations();
-}
+size_type PyWGraph::maxIterations() const { return obj->maxIterations(); }
 
 void PyWGraph::errorThreshold(const value_type& threshold) {
   obj->errorThreshold(threshold);
 }
 
-value_type PyWGraph::errorThreshold() const {
-  return obj->errorThreshold();
-}
+value_type PyWGraph::errorThreshold() const { return obj->errorThreshold(); }
 
 // =============================================================================
 // Graph construction
 // =============================================================================
 
 PyWStatePtr_t PyWGraph::createState(const std::string& nodeName, bool waypoint,
-                                     int priority) {
+                                    int priority) {
   if (obj->stateSelector()) {
     hpp::manipulation::graph::StatePtr_t state =
         obj->stateSelector()->createState(nodeName, waypoint, priority);
@@ -287,62 +293,61 @@ PyWStatePtr_t PyWGraph::createState(const std::string& nodeName, bool waypoint,
   }
 }
 
-PyWEdgePtr_t PyWGraph::createTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo,
-                                  const std::string& transitionName, int w,
-                                  PyWStatePtr_t isInState) {
+PyWEdgePtr_t PyWGraph::createTransition(PyWStatePtr_t nodeFrom,
+                                        PyWStatePtr_t nodeTo,
+                                        const std::string& transitionName,
+                                        int w, PyWStatePtr_t isInState) {
   using namespace hpp::manipulation::graph;
-  EdgePtr_t edge = nodeFrom->obj->linkTo(
-      transitionName, nodeTo->obj, w, (State::EdgeFactory)Edge::create);
+  EdgePtr_t edge = nodeFrom->obj->linkTo(transitionName, nodeTo->obj, w,
+                                         (State::EdgeFactory)Edge::create);
   edge->state(isInState->obj);
   return std::shared_ptr<PyWEdge>(new PyWEdge(edge));
 }
 
 // Updated createWaypointTransition method
-PyWEdgePtr_t PyWGraph::createWaypointTransition(PyWStatePtr_t nodeFrom,
-                                                PyWStatePtr_t nodeTo,
-                                                const std::string& edgeName, 
-                                                int nb,
-                                                int w, 
-                                                PyWStatePtr_t isInState,
-                                                bool automaticBuilder) {
-    try {
-        using namespace hpp::manipulation::graph;
-        EdgePtr_t edge_pc = nodeFrom->obj->linkTo(
-            edgeName, nodeTo->obj, w, (State::EdgeFactory)WaypointEdge::create);
-        edge_pc->state(isInState->obj);
+PyWEdgePtr_t PyWGraph::createWaypointTransition(
+    PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo, const std::string& edgeName,
+    int nb, int w, PyWStatePtr_t isInState, bool automaticBuilder) {
+  try {
+    using namespace hpp::manipulation::graph;
+    EdgePtr_t edge_pc = nodeFrom->obj->linkTo(
+        edgeName, nodeTo->obj, w, (State::EdgeFactory)WaypointEdge::create);
+    edge_pc->state(isInState->obj);
 
-        auto waypoint_edge = HPP_DYNAMIC_PTR_CAST(WaypointEdge, edge_pc);
-        waypoint_edge->nbWaypoints(nb);
+    auto waypoint_edge = HPP_DYNAMIC_PTR_CAST(WaypointEdge, edge_pc);
+    waypoint_edge->nbWaypoints(nb);
 
-        if (automaticBuilder) {
-            PyWStatePtr_t previous = nodeFrom;
-            
-            for (int i = 0; i < nb; ++i) {
-                std::string waypoint_state_name = edgeName + "_n" + std::to_string(i);
-                std::string waypoint_edge_name = edgeName + "_e" + std::to_string(i);
-                
-                PyWStatePtr_t waypoint_state = createState(waypoint_state_name, true, 0);
-                
-                PyWEdgePtr_t waypoint_individual_edge = createTransition(
-                    previous, waypoint_state, waypoint_edge_name, -1, isInState
-                );
-                
-                waypoint_edge->setWaypoint(i, waypoint_individual_edge->obj, waypoint_state->obj);
-                
-                previous = waypoint_state;
-            }
-        }
-        return std::shared_ptr<PyWEdge>(new PyWEdge(edge_pc));
-        
-    } catch (const std::exception& exc) {
-        throw std::logic_error(exc.what());
+    if (automaticBuilder) {
+      PyWStatePtr_t previous = nodeFrom;
+
+      for (int i = 0; i < nb; ++i) {
+        std::string waypoint_state_name = edgeName + "_n" + std::to_string(i);
+        std::string waypoint_edge_name = edgeName + "_e" + std::to_string(i);
+
+        PyWStatePtr_t waypoint_state =
+            createState(waypoint_state_name, true, 0);
+
+        PyWEdgePtr_t waypoint_individual_edge = createTransition(
+            previous, waypoint_state, waypoint_edge_name, -1, isInState);
+
+        waypoint_edge->setWaypoint(i, waypoint_individual_edge->obj,
+                                   waypoint_state->obj);
+
+        previous = waypoint_state;
+      }
     }
+    return std::shared_ptr<PyWEdge>(new PyWEdge(edge_pc));
+
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
 }
 
 PyWEdgePtr_t PyWGraph::createLevelSetTransition(PyWStatePtr_t nodeFrom,
-                                           PyWStatePtr_t nodeTo,
-                                           const std::string& edgeName, int w,
-                                           PyWStatePtr_t isInState) {
+                                                PyWStatePtr_t nodeTo,
+                                                const std::string& edgeName,
+                                                int w,
+                                                PyWStatePtr_t isInState) {
   try {
     using namespace hpp::manipulation::graph;
     EdgePtr_t edge = nodeFrom->obj->linkTo(
@@ -391,8 +396,8 @@ bool PyWGraph::isShort(PyWEdgePtr_t edge) {
 }
 
 void PyWGraph::getNodesConnectedByTransition(PyWEdgePtr_t edge,
-                                        std::string& nodeFrom,
-                                        std::string& nodeTo) {
+                                             std::string& nodeFrom,
+                                             std::string& nodeTo) {
   try {
     nodeFrom = edge->obj->stateFrom()->name();
     nodeTo = edge->obj->stateTo()->name();
@@ -417,30 +422,30 @@ size_t PyWGraph::getWeight(PyWEdgePtr_t edge) {
   }
 }
 
-void PyWGraph::setWaypoint(PyWEdgePtr_t waypointEdge, int index, 
+void PyWGraph::setWaypoint(PyWEdgePtr_t waypointEdge, int index,
                            PyWEdgePtr_t edge, PyWStatePtr_t state) {
-    try {
-        using namespace hpp::manipulation::graph;
-        
-        // Cast to WaypointEdge
-        auto waypoint_edge = HPP_DYNAMIC_PTR_CAST(WaypointEdge, waypointEdge->obj);
-        if (!waypoint_edge) {
-            throw std::logic_error("Edge is not a WaypointEdge");
-        }
-        
-        // Validate index
-        if (index < 0 || static_cast<std::size_t>(index) > waypoint_edge->nbWaypoints()) {
-            throw std::logic_error("Invalid waypoint index");
-        }
-        
-        // Set the waypoint
-        waypoint_edge->setWaypoint(index, edge->obj, state->obj);
-        
-    } catch (const std::exception& exc) {
-        throw std::logic_error(exc.what());
-    }
-}
+  try {
+    using namespace hpp::manipulation::graph;
 
+    // Cast to WaypointEdge
+    auto waypoint_edge = HPP_DYNAMIC_PTR_CAST(WaypointEdge, waypointEdge->obj);
+    if (!waypoint_edge) {
+      throw std::logic_error("Edge is not a WaypointEdge");
+    }
+
+    // Validate index
+    if (index < 0 ||
+        static_cast<std::size_t>(index) > waypoint_edge->nbWaypoints()) {
+      throw std::logic_error("Invalid waypoint index");
+    }
+
+    // Set the waypoint
+    waypoint_edge->setWaypoint(index, edge->obj, state->obj);
+
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
 
 // =============================================================================
 // State queries
@@ -460,7 +465,7 @@ std::string PyWGraph::getState(ConfigurationIn_t input) {
 // =============================================================================
 
 void PyWGraph::addNumericalConstraint(PyWStatePtr_t node,
-                                       const ImplicitPtr_t& constraint) {
+                                      const ImplicitPtr_t& constraint) {
   node->obj->addNumericalConstraint(constraint);
 }
 
@@ -496,7 +501,8 @@ void PyWGraph::addNumericalConstraintsToTransition(
   }
 }
 
-void PyWGraph::addNumericalConstraintsToGraph(const boost::python::list& py_constraints) {
+void PyWGraph::addNumericalConstraintsToGraph(
+    const boost::python::list& py_constraints) {
   auto constraints =
       extract_vector<std::shared_ptr<hpp::constraints::Implicit>>(
           py_constraints);
@@ -527,10 +533,12 @@ void PyWGraph::addNumericalConstraintsForPath(
   }
 }
 
-boost::python::list PyWGraph::getNumericalConstraintsForState(PyWStatePtr_t component) {
+boost::python::list PyWGraph::getNumericalConstraintsForState(
+    PyWStatePtr_t component) {
   return to_python_list(component->obj->numericalConstraints());
 }
-boost::python::list PyWGraph::getNumericalConstraintsForEdge(PyWEdgePtr_t component) {
+boost::python::list PyWGraph::getNumericalConstraintsForEdge(
+    PyWEdgePtr_t component) {
   return to_python_list(component->obj->numericalConstraints());
 }
 boost::python::list PyWGraph::getNumericalConstraintsForGraph() {
@@ -542,8 +550,8 @@ void PyWGraph::resetConstraints(PyWStatePtr_t component) {
 }
 
 void PyWGraph::registerConstraints(const ImplicitPtr_t& constraint,
-                                    const ImplicitPtr_t& complement,
-                                    const ImplicitPtr_t& both) {
+                                   const ImplicitPtr_t& complement,
+                                   const ImplicitPtr_t& both) {
   try {
     obj->registerConstraints(constraint, complement, both);
   } catch (const std::exception& exc) {
@@ -556,8 +564,8 @@ void PyWGraph::registerConstraints(const ImplicitPtr_t& constraint,
 // =============================================================================
 
 bool PyWGraph::getConfigErrorForState(PyWStatePtr_t component,
-                                       ConfigurationIn_t input,
-                                       hpp::core::vector_t& error) {
+                                      ConfigurationIn_t input,
+                                      hpp::core::vector_t& error) {
   try {
     return obj->getConfigErrorForState(input, component->obj, error);
   } catch (const std::exception& exc) {
@@ -566,8 +574,8 @@ bool PyWGraph::getConfigErrorForState(PyWStatePtr_t component,
 }
 
 bool PyWGraph::getConfigErrorForTransition(PyWEdgePtr_t edge,
-                                      ConfigurationIn_t input,
-                                      hpp::core::vector_t& error) {
+                                           ConfigurationIn_t input,
+                                           hpp::core::vector_t& error) {
   try {
     // Check if steering method is properly initialized
     if (!edge->obj->parentGraph()->problem()->manipulationSteeringMethod() ||
@@ -583,17 +591,15 @@ bool PyWGraph::getConfigErrorForTransition(PyWEdgePtr_t edge,
   }
 }
 
-bool PyWGraph::getConfigErrorForTransitionLeaf(ConfigurationIn_t leafConfig,
-                                          ConfigurationIn_t config,
-                                          const PyWEdgePtr_t& edge,
-                                          hpp::core::vector_t& error) const {
+bool PyWGraph::getConfigErrorForTransitionLeaf(
+    ConfigurationIn_t leafConfig, ConfigurationIn_t config,
+    const PyWEdgePtr_t& edge, hpp::core::vector_t& error) const {
   return obj->getConfigErrorForEdgeLeaf(leafConfig, config, edge->obj, error);
 }
 
-bool PyWGraph::getConfigErrorForTransitionTarget(ConfigurationIn_t leafConfig,
-                                            ConfigurationIn_t config,
-                                            const PyWEdgePtr_t& edge,
-                                            hpp::core::vector_t& error) const {
+bool PyWGraph::getConfigErrorForTransitionTarget(
+    ConfigurationIn_t leafConfig, ConfigurationIn_t config,
+    const PyWEdgePtr_t& edge, hpp::core::vector_t& error) const {
   return obj->getConfigErrorForEdgeTarget(leafConfig, config, edge->obj, error);
 }
 
@@ -602,7 +608,7 @@ bool PyWGraph::getConfigErrorForTransitionTarget(ConfigurationIn_t leafConfig,
 // =============================================================================
 
 ConstraintResult PyWGraph::applyStateConstraints(PyWStatePtr_t state,
-                                                  ConfigurationIn_t input) {
+                                                 ConfigurationIn_t input) {
   using namespace hpp::manipulation;
   ConstraintSetPtr_t constraint(state->obj->configConstraint());
   value_type residualError(std::numeric_limits<value_type>::quiet_NaN());
@@ -617,8 +623,8 @@ ConstraintResult PyWGraph::applyStateConstraints(PyWStatePtr_t state,
 }
 
 ConstraintResult PyWGraph::applyLeafConstraints(PyWEdgePtr_t transition,
-                                                 ConfigurationIn_t q_rhs,
-                                                 ConfigurationIn_t input) {
+                                                ConfigurationIn_t q_rhs,
+                                                ConfigurationIn_t input) {
   using namespace hpp::manipulation;
   ConstraintSetPtr_t constraint(transition->obj->pathConstraint());
   value_type residualError(std::numeric_limits<value_type>::quiet_NaN());
@@ -634,8 +640,8 @@ ConstraintResult PyWGraph::applyLeafConstraints(PyWEdgePtr_t transition,
 }
 
 ConstraintResult PyWGraph::generateTargetConfig(PyWEdgePtr_t transition,
-                                                 ConfigurationIn_t q_rhs,
-                                                 ConfigurationIn_t input) {
+                                                ConfigurationIn_t q_rhs,
+                                                ConfigurationIn_t input) {
   using namespace hpp::manipulation;
   ConstraintSetPtr_t constraint(transition->obj->targetConstraint());
   value_type residualError(std::numeric_limits<value_type>::quiet_NaN());
@@ -655,8 +661,8 @@ ConstraintResult PyWGraph::generateTargetConfig(PyWEdgePtr_t transition,
 // =============================================================================
 
 void PyWGraph::addLevelSetFoliation(PyWEdgePtr_t edge,
-                                     const boost::python::list& condNC,
-                                     const boost::python::list& paramNC) {
+                                    const boost::python::list& condNC,
+                                    const boost::python::list& paramNC) {
   try {
     using namespace hpp::manipulation::graph;
     auto levelSetEdge = HPP_DYNAMIC_PTR_CAST(LevelSetEdge, edge->obj);
@@ -698,16 +704,18 @@ boost::python::list PyWGraph::getSecurityMarginMatrixForTransition(
   }
 }
 
-void PyWGraph::setSecurityMarginForTransition(PyWEdgePtr_t edge, const char* joint1,
-                                         const char* joint2, double margin) {
+void PyWGraph::setSecurityMarginForTransition(PyWEdgePtr_t edge,
+                                              const char* joint1,
+                                              const char* joint2,
+                                              double margin) {
   using namespace hpp::manipulation;
   try {
     JointPtr_t j1(obj->robot()->getJointByName(joint1));
     JointPtr_t j2(obj->robot()->getJointByName(joint2));
-    
+
     size_type i1 = j1 ? j1->index() : 0;
     size_type i2 = j2 ? j2->index() : 0;
-    
+
     edge->obj->securityMarginForPair(i1, i2, margin);
   } catch (const std::exception& exc) {
     throw std::logic_error(exc.what());
@@ -741,8 +749,8 @@ boost::python::list PyWGraph::getRelativeMotionMatrix(PyWEdgePtr_t edge) {
 }
 
 void PyWGraph::removeCollisionPairFromTransition(PyWEdgePtr_t edge,
-                                            const char* joint1,
-                                            const char* joint2) {
+                                                 const char* joint1,
+                                                 const char* joint2) {
   try {
     using hpp::core::RelativeMotion;
     RelativeMotion::matrix_type m(edge->obj->relativeMotion());
@@ -766,7 +774,7 @@ void PyWGraph::removeCollisionPairFromTransition(PyWEdgePtr_t edge,
 // =============================================================================
 
 void PyWGraph::createSubGraph(const char* subgraphName,
-                               hpp::core::RoadmapPtr_t roadmap) {
+                              hpp::core::RoadmapPtr_t roadmap) {
   using namespace hpp::manipulation;
   try {
     graph::GuidedStateSelectorPtr_t ns =
@@ -786,7 +794,7 @@ void PyWGraph::setTargetNodeList(const boost::python::list& py_nodes) {
     throw std::logic_error(
         "The state selector is not of type GuidedStateSelector.");
   }
-  
+
   try {
     graph::States_t nl;
     for (size_t i = 0; i < nodes.size(); ++i) {
@@ -861,160 +869,162 @@ void PyWGraph::initialize() {
   }
 }
 
-typedef hpp::pinocchio::vector3_t vector3_t; 
+typedef hpp::pinocchio::vector3_t vector3_t;
 typedef std::vector<vector3_t> Shape_t;
 typedef std::pair<JointPtr_t, Shape_t> JointAndShape_t;
 typedef std::vector<JointAndShape_t> JointAndShapes_t;
 typedef hpp::constraints::ImplicitPtr_t ImplicitPtr_t;
-boost::python::tuple PyWGraph::createPlacementConstraint(const std::string& name,
-                                        const boost::python::list& py_surface1,
-                                        const boost::python::list& py_surface2,
-                                        const value_type& margin = 1e-4) {
-   try {
-       auto surface1 = extract_vector<std::string>(py_surface1);
-       auto surface2 = extract_vector<std::string>(py_surface2);
+boost::python::tuple PyWGraph::createPlacementConstraint(
+    const std::string& name, const boost::python::list& py_surface1,
+    const boost::python::list& py_surface2, const value_type& margin = 1e-4) {
+  try {
+    auto surface1 = extract_vector<std::string>(py_surface1);
+    auto surface2 = extract_vector<std::string>(py_surface2);
 
-       bool explicit_(true);
-       if (!robot->obj) throw std::runtime_error("No robot loaded");
-       JointAndShapes_t floorSurfaces, objectSurfaces, l;
-       
-       for (std::vector<std::string>::const_iterator it1 = surface1.begin(); it1 != surface1.end(); ++it1) {
-           if (!robot->obj->jointAndShapes.has(*it1))
-               throw std::runtime_error("First list of triangles not found.");
-           l = robot->obj->jointAndShapes.get(*it1);
-           objectSurfaces.insert(objectSurfaces.end(), l.begin(), l.end());
-           
-           for (auto js : l) {
-               JointPtr_t j(js.first);
-               if ((j->parentJoint()) ||
-                   ((*j->configurationSpace() != *hpp::pinocchio::LiegroupSpace::SE3()) &&
-                    (*j->configurationSpace() != *hpp::pinocchio::LiegroupSpace::R3xSO3()))) {
-                   explicit_ = false;
-               }
-           }
-       }
+    bool explicit_(true);
+    if (!robot->obj) throw std::runtime_error("No robot loaded");
+    JointAndShapes_t floorSurfaces, objectSurfaces, l;
 
-       for (std::vector<std::string>::const_iterator it2 = surface2.begin(); it2 != surface2.end(); ++it2) {
-           if (robot->obj->jointAndShapes.has(*it2)) {
-               l = robot->obj->jointAndShapes.get(*it2);
-           }
-           else if (problem->jointAndShapes.has(*it2)) {
-               l = problem->jointAndShapes.get(*it2);
-           }
-           else {
-               throw std::runtime_error("Second list of triangles not found.");
-           }
-           floorSurfaces.insert(floorSurfaces.end(), l.begin(), l.end());
-       }
+    for (std::vector<std::string>::const_iterator it1 = surface1.begin();
+         it1 != surface1.end(); ++it1) {
+      if (!robot->obj->jointAndShapes.has(*it1))
+        throw std::runtime_error("First list of triangles not found.");
+      l = robot->obj->jointAndShapes.get(*it1);
+      objectSurfaces.insert(objectSurfaces.end(), l.begin(), l.end());
 
-       if (explicit_) {
-           typedef hpp::constraints::explicit_::ConvexShapeContact Constraint_t;
-           Constraint_t::Constraints_t constraints(
-               Constraint_t::createConstraintAndComplement(name, robot->obj, floorSurfaces,
-                                                           objectSurfaces, margin));
-           
-           assert(hpp::dynamic_pointer_cast<hpp::constraints::ConvexShapeContact>(
-               std::get<0>(constraints)->functionPtr()));
-           hpp::constraints::ConvexShapeContactPtr_t contactFunction(
-               hpp::static_pointer_cast<hpp::constraints::ConvexShapeContact>(
-                   std::get<0>(constraints)->functionPtr()));
-           contactFunction->setNormalMargin(margin);
-           
-           return boost::python::make_tuple(
-               std::get<0>(constraints),
-               std::get<1>(constraints),
-               std::get<2>(constraints)
-           );
-           
-       } else {
-           using hpp::constraints::ComparisonTypes_t;
-           using hpp::constraints::Equality;
-           using hpp::constraints::EqualToZero;
-           using hpp::constraints::Implicit;
-           
-           std::pair<hpp::constraints::ConvexShapeContactPtr_t,
-                     hpp::constraints::ConvexShapeContactComplementPtr_t>
-               functions(hpp::constraints::ConvexShapeContactComplement::createPair(
-                   name, robot->obj, floorSurfaces, objectSurfaces));
-           
-           functions.first->setNormalMargin(margin);
+      for (auto js : l) {
+        JointPtr_t j(js.first);
+        if ((j->parentJoint()) ||
+            ((*j->configurationSpace() !=
+              *hpp::pinocchio::LiegroupSpace::SE3()) &&
+             (*j->configurationSpace() !=
+              *hpp::pinocchio::LiegroupSpace::R3xSO3()))) {
+          explicit_ = false;
+        }
+      }
+    }
 
-           auto constraint = Implicit::create(functions.first, 5 * EqualToZero);
-           auto complement = Implicit::create(
-               functions.second,
-               ComparisonTypes_t(functions.second->outputSize(), Equality));
-           
-           return boost::python::make_tuple(constraint, complement, boost::python::object());
-       }
-       
-   } catch (const std::exception& exc) {
-       throw std::logic_error(exc.what());
-   }
+    for (std::vector<std::string>::const_iterator it2 = surface2.begin();
+         it2 != surface2.end(); ++it2) {
+      if (robot->obj->jointAndShapes.has(*it2)) {
+        l = robot->obj->jointAndShapes.get(*it2);
+      } else if (problem->jointAndShapes.has(*it2)) {
+        l = problem->jointAndShapes.get(*it2);
+      } else {
+        throw std::runtime_error("Second list of triangles not found.");
+      }
+      floorSurfaces.insert(floorSurfaces.end(), l.begin(), l.end());
+    }
+
+    if (explicit_) {
+      typedef hpp::constraints::explicit_::ConvexShapeContact Constraint_t;
+      Constraint_t::Constraints_t constraints(
+          Constraint_t::createConstraintAndComplement(
+              name, robot->obj, floorSurfaces, objectSurfaces, margin));
+
+      assert(hpp::dynamic_pointer_cast<hpp::constraints::ConvexShapeContact>(
+          std::get<0>(constraints)->functionPtr()));
+      hpp::constraints::ConvexShapeContactPtr_t contactFunction(
+          hpp::static_pointer_cast<hpp::constraints::ConvexShapeContact>(
+              std::get<0>(constraints)->functionPtr()));
+      contactFunction->setNormalMargin(margin);
+
+      return boost::python::make_tuple(std::get<0>(constraints),
+                                       std::get<1>(constraints),
+                                       std::get<2>(constraints));
+
+    } else {
+      using hpp::constraints::ComparisonTypes_t;
+      using hpp::constraints::Equality;
+      using hpp::constraints::EqualToZero;
+      using hpp::constraints::Implicit;
+
+      std::pair<hpp::constraints::ConvexShapeContactPtr_t,
+                hpp::constraints::ConvexShapeContactComplementPtr_t>
+          functions(hpp::constraints::ConvexShapeContactComplement::createPair(
+              name, robot->obj, floorSurfaces, objectSurfaces));
+
+      functions.first->setNormalMargin(margin);
+
+      auto constraint = Implicit::create(functions.first, 5 * EqualToZero);
+      auto complement = Implicit::create(
+          functions.second,
+          ComparisonTypes_t(functions.second->outputSize(), Equality));
+
+      return boost::python::make_tuple(constraint, complement,
+                                       boost::python::object());
+    }
+
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
 }
 
 boost::python::tuple PyWGraph::createPlacementConstraint1(
     const std::string& name, const boost::python::list& py_surface1,
     const boost::python::list& py_surface2, const value_type& margin) {
-    return createPlacementConstraint(name, py_surface1, py_surface2, margin);
+  return createPlacementConstraint(name, py_surface1, py_surface2, margin);
 }
 boost::python::tuple PyWGraph::createPlacementConstraint2(
     const std::string& name, const boost::python::list& py_surface1,
     const boost::python::list& py_surface2) {
-    return createPlacementConstraint(name, py_surface1, py_surface2);
+  return createPlacementConstraint(name, py_surface1, py_surface2);
 }
 
-ImplicitPtr_t PyWGraph::createPrePlacementConstraint(const std::string& name,
-                                           const boost::python::list& py_surface1,
-                                           const boost::python::list& py_surface2,
-                                           const value_type& width,
-                                           const value_type& margin= 1e-4) {
-   try {
-       auto surface1 = extract_vector<std::string>(py_surface1);
-       auto surface2 = extract_vector<std::string>(py_surface2);
+ImplicitPtr_t PyWGraph::createPrePlacementConstraint(
+    const std::string& name, const boost::python::list& py_surface1,
+    const boost::python::list& py_surface2, const value_type& width,
+    const value_type& margin = 1e-4) {
+  try {
+    auto surface1 = extract_vector<std::string>(py_surface1);
+    auto surface2 = extract_vector<std::string>(py_surface2);
 
-       if (!robot->obj) throw std::runtime_error("No robot loaded");
-       JointAndShapes_t floorSurfaces, objectSurfaces, l;
-       
-       for (std::vector<std::string>::const_iterator it1 = surface1.begin(); it1 != surface1.end(); ++it1) {
-           if (!robot->obj->jointAndShapes.has(*it1))
-               throw std::runtime_error("First list of triangles not found.");
-           l = robot->obj->jointAndShapes.get(*it1);
-           objectSurfaces.insert(objectSurfaces.end(), l.begin(), l.end());
-       }
+    if (!robot->obj) throw std::runtime_error("No robot loaded");
+    JointAndShapes_t floorSurfaces, objectSurfaces, l;
 
-       for (std::vector<std::string>::const_iterator it2 = surface2.begin(); it2 != surface2.end(); ++it2) {
-           if (robot->obj->jointAndShapes.has(*it2)) {
-               l = robot->obj->jointAndShapes.get(*it2);
-           }
-           else if (problem->jointAndShapes.has(*it2)) {
-               l = problem->jointAndShapes.get(*it2);
-           }
-           else {
-               throw std::runtime_error("Second list of triangles not found.");
-           }
-           floorSurfaces.insert(floorSurfaces.end(), l.begin(), l.end());
-       }
+    for (std::vector<std::string>::const_iterator it1 = surface1.begin();
+         it1 != surface1.end(); ++it1) {
+      if (!robot->obj->jointAndShapes.has(*it1))
+        throw std::runtime_error("First list of triangles not found.");
+      l = robot->obj->jointAndShapes.get(*it1);
+      objectSurfaces.insert(objectSurfaces.end(), l.begin(), l.end());
+    }
 
-       hpp::constraints::ConvexShapeContactPtr_t cvxShape(
-           hpp::constraints::ConvexShapeContact::create(name, robot->obj, floorSurfaces,
-                                                        objectSurfaces));
-       cvxShape->setNormalMargin(margin + width);
-       
-       return hpp::constraints::Implicit::create(cvxShape, 5 * hpp::constraints::EqualToZero);
-       
-   } catch (const std::exception& exc) {
-       throw std::logic_error(exc.what());
-   }
+    for (std::vector<std::string>::const_iterator it2 = surface2.begin();
+         it2 != surface2.end(); ++it2) {
+      if (robot->obj->jointAndShapes.has(*it2)) {
+        l = robot->obj->jointAndShapes.get(*it2);
+      } else if (problem->jointAndShapes.has(*it2)) {
+        l = problem->jointAndShapes.get(*it2);
+      } else {
+        throw std::runtime_error("Second list of triangles not found.");
+      }
+      floorSurfaces.insert(floorSurfaces.end(), l.begin(), l.end());
+    }
+
+    hpp::constraints::ConvexShapeContactPtr_t cvxShape(
+        hpp::constraints::ConvexShapeContact::create(
+            name, robot->obj, floorSurfaces, objectSurfaces));
+    cvxShape->setNormalMargin(margin + width);
+
+    return hpp::constraints::Implicit::create(
+        cvxShape, 5 * hpp::constraints::EqualToZero);
+
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
 }
 ImplicitPtr_t PyWGraph::createPrePlacementConstraint1(
     const std::string& name, const boost::python::list& py_surface1,
-    const boost::python::list& py_surface2, const value_type& width, const value_type& margin) {
-    return createPrePlacementConstraint(name, py_surface1, py_surface2, width, margin);
+    const boost::python::list& py_surface2, const value_type& width,
+    const value_type& margin) {
+  return createPrePlacementConstraint(name, py_surface1, py_surface2, width,
+                                      margin);
 }
 ImplicitPtr_t PyWGraph::createPrePlacementConstraint2(
     const std::string& name, const boost::python::list& py_surface1,
     const boost::python::list& py_surface2, const value_type& width) {
-    return createPrePlacementConstraint(name, py_surface1, py_surface2, width);
+  return createPrePlacementConstraint(name, py_surface1, py_surface2, width);
 }
 
 // =============================================================================
@@ -1025,29 +1035,35 @@ using namespace boost::python;
 
 void exposeGraph() {
   class_<PyWState, PyWStatePtr_t>("State", no_init);
-  
+
   class_<PyWEdge, PyWEdgePtr_t>("Transition", no_init);
 
-  class_<PyWGraph>("Graph", init<const std::string&, const PyWDevicePtr_t&,
-                                const PyWProblemPtr_t&>())
+  class_<PyWGraph>(
+      "Graph",
+      init<const std::string&, const PyWDevicePtr_t&, const PyWProblemPtr_t&>())
 
       .def_readwrite("robot", &PyWGraph::robot)
       // Configuration methods
-      .PYHPP_DEFINE_GETTER_SETTER(PyWGraph, maxIterations, hpp::manipulation::size_type)
-      .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(PyWGraph, errorThreshold, hpp::manipulation::value_type)
+      .PYHPP_DEFINE_GETTER_SETTER(PyWGraph, maxIterations,
+                                  hpp::manipulation::size_type)
+      .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(PyWGraph, errorThreshold,
+                                            hpp::manipulation::value_type)
 
       // Graph construction
       .PYHPP_DEFINE_METHOD1(PyWGraph, createState, DOC_CREATESTATE)
       .PYHPP_DEFINE_METHOD1(PyWGraph, createTransition, DOC_CREATETRANSITION)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, createWaypointTransition, DOC_CREATEWAYPOINTTRANSITION)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, createLevelSetTransition, DOC_CREATELEVELSETTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, createWaypointTransition,
+                            DOC_CREATEWAYPOINTTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, createLevelSetTransition,
+                            DOC_CREATELEVELSETTRANSITION)
 
       // Transition/State management
       .PYHPP_DEFINE_METHOD1(PyWGraph, setContainingNode, DOC_SETCONTAININGNODE)
       .PYHPP_DEFINE_METHOD1(PyWGraph, getContainingNode, DOC_GETCONTAININGNODE)
       .PYHPP_DEFINE_METHOD1(PyWGraph, setShort, DOC_SETSHORT)
       .PYHPP_DEFINE_METHOD1(PyWGraph, isShort, DOC_ISSHORT)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getNodesConnectedByTransition, DOC_GETNODESCONNECTEDBYTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getNodesConnectedByTransition,
+                            DOC_GETNODESCONNECTEDBYTRANSITION)
       .PYHPP_DEFINE_METHOD1(PyWGraph, setWeight, DOC_SETWEIGHT)
       .PYHPP_DEFINE_METHOD1(PyWGraph, getWeight, DOC_GETWEIGHT)
       .PYHPP_DEFINE_METHOD1(PyWGraph, setWaypoint, DOC_SETWAYPOINT)
@@ -1056,50 +1072,79 @@ void exposeGraph() {
       .PYHPP_DEFINE_METHOD1(PyWGraph, getState, DOC_GETSTATE)
 
       // Constraint management
-      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraint, DOC_ADDNUMERICALCONSTRAINT)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraintsToState, DOC_ADDNUMERICALCONSTRAINTSTOSTATE)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraintsToTransition, DOC_ADDNUMERICALCONSTRAINTSTOTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraint,
+                            DOC_ADDNUMERICALCONSTRAINT)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraintsToState,
+                            DOC_ADDNUMERICALCONSTRAINTSTOSTATE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraintsToTransition,
+                            DOC_ADDNUMERICALCONSTRAINTSTOTRANSITION)
       .PYHPP_DEFINE_METHOD(PyWGraph, addNumericalConstraintsToGraph)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraintsForPath, DOC_ADDNUMERICALCONSTRAINTSFORPATH)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraintsForState, DOC_GETNUMERICALCONSTRAINTSFORSTATE)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraintsForEdge, DOC_GETNUMERICALCONSTRAINTSFOREDGE)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraintsForGraph, DOC_GETNUMERICALCONSTRAINTSFORGRAPH)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraintsForPath,
+                            DOC_ADDNUMERICALCONSTRAINTSFORPATH)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraintsForState,
+                            DOC_GETNUMERICALCONSTRAINTSFORSTATE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraintsForEdge,
+                            DOC_GETNUMERICALCONSTRAINTSFOREDGE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraintsForGraph,
+                            DOC_GETNUMERICALCONSTRAINTSFORGRAPH)
       .PYHPP_DEFINE_METHOD1(PyWGraph, resetConstraints, DOC_RESETCONSTRAINTS)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, registerConstraints, DOC_REGISTERCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, registerConstraints,
+                            DOC_REGISTERCONSTRAINTS)
 
-      .def("createPlacementConstraint", &PyWGraph::createPlacementConstraint1, DOC_CREATEPLACEMENTCONSTRAINT)
-      .def("createPlacementConstraint", &PyWGraph::createPlacementConstraint2, DOC_CREATEPLACEMENTCONSTRAINT)
-      .def("createPrePlacementConstraint", &PyWGraph::createPrePlacementConstraint1, DOC_CREATEPREPLACEMENTCONSTRAINT)
-      .def("createPrePlacementConstraint", &PyWGraph::createPrePlacementConstraint2, DOC_CREATEPREPLACEMENTCONSTRAINT)
+      .def("createPlacementConstraint", &PyWGraph::createPlacementConstraint1,
+           DOC_CREATEPLACEMENTCONSTRAINT)
+      .def("createPlacementConstraint", &PyWGraph::createPlacementConstraint2,
+           DOC_CREATEPLACEMENTCONSTRAINT)
+      .def("createPrePlacementConstraint",
+           &PyWGraph::createPrePlacementConstraint1,
+           DOC_CREATEPREPLACEMENTCONSTRAINT)
+      .def("createPrePlacementConstraint",
+           &PyWGraph::createPrePlacementConstraint2,
+           DOC_CREATEPREPLACEMENTCONSTRAINT)
 
       // Configuration error checking
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForState, DOC_GETCONFIGERRORFORSTATE)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForTransition, DOC_GETCONFIGERRORFORTRANSITION)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForTransitionLeaf, DOC_GETCONFIGERRORFORTRANSITIONLEAF)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForTransitionTarget, DOC_GETCONFIGERRORFORTRANSITIONTARGET)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForState,
+                            DOC_GETCONFIGERRORFORSTATE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForTransition,
+                            DOC_GETCONFIGERRORFORTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForTransitionLeaf,
+                            DOC_GETCONFIGERRORFORTRANSITIONLEAF)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForTransitionTarget,
+                            DOC_GETCONFIGERRORFORTRANSITIONTARGET)
 
       // Constraint application
-      .PYHPP_DEFINE_METHOD1(PyWGraph, applyStateConstraints, DOC_APPLYSTATECONSTRAINTS)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, applyLeafConstraints, DOC_APPLYLEAFCONSTRAINTS)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, generateTargetConfig, DOC_GENERATETARGETCONFIG)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, applyStateConstraints,
+                            DOC_APPLYSTATECONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, applyLeafConstraints,
+                            DOC_APPLYLEAFCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, generateTargetConfig,
+                            DOC_GENERATETARGETCONFIG)
 
       // Level set transitions
-      .PYHPP_DEFINE_METHOD1(PyWGraph, addLevelSetFoliation, DOC_ADDLEVELSETFOLIATION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addLevelSetFoliation,
+                            DOC_ADDLEVELSETFOLIATION)
 
       // Security margins and collision
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getSecurityMarginMatrixForTransition, DOC_GETSECURITYMARGINMATRIXFORTRANSITION)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, setSecurityMarginForTransition, DOC_SETSECURITYMARGINFORTRANSITION)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getRelativeMotionMatrix, DOC_GETRELATIVEMOTIONMATRIX)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, removeCollisionPairFromTransition, DOC_REMOVECOLLISIONPAIRFROMTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getSecurityMarginMatrixForTransition,
+                            DOC_GETSECURITYMARGINMATRIXFORTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, setSecurityMarginForTransition,
+                            DOC_SETSECURITYMARGINFORTRANSITION)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getRelativeMotionMatrix,
+                            DOC_GETRELATIVEMOTIONMATRIX)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, removeCollisionPairFromTransition,
+                            DOC_REMOVECOLLISIONPAIRFROMTRANSITION)
 
       // Subgraph management
       .PYHPP_DEFINE_METHOD1(PyWGraph, createSubGraph, DOC_CREATESUBGRAPH)
       .PYHPP_DEFINE_METHOD1(PyWGraph, setTargetNodeList, DOC_SETTARGETNODELIST)
 
       // Display and debugging
-      .PYHPP_DEFINE_METHOD1(PyWGraph, displayStateConstraints, DOC_DISPLAYSTATECONSTRAINTS)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, displayTransitionConstraints, DOC_DISPLAYTRANSITIONCONSTRAINTS)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, displayTransitionTargetConstraints, DOC_DISPLAYTRANSITIONTARGETCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, displayStateConstraints,
+                            DOC_DISPLAYSTATECONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, displayTransitionConstraints,
+                            DOC_DISPLAYTRANSITIONCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, displayTransitionTargetConstraints,
+                            DOC_DISPLAYTRANSITIONTARGETCONSTRAINTS)
       .PYHPP_DEFINE_METHOD1(PyWGraph, display, DOC_DISPLAY)
 
       // Initialization

--- a/src/pyhpp/manipulation/graph.cc
+++ b/src/pyhpp/manipulation/graph.cc
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2025, CNRS
-// Authors: Florent Lamiraux
+// Authors: Florent Lamiraux, Paul Sardin
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -29,197 +29,661 @@
 
 #include <../src/pyhpp/manipulation/device.hh>
 #include <../src/pyhpp/manipulation/graph.hh>
+#include <../src/pyhpp/manipulation/problem.hh>
+
 #include <boost/python.hpp>
 #include <hpp/manipulation/graph/edge.hh>
 #include <hpp/manipulation/graph/graph.hh>
+#include <hpp/manipulation/graph/guided-state-selector.hh>
 #include <hpp/manipulation/graph/state-selector.hh>
 #include <hpp/manipulation/graph/state.hh>
+#include <hpp/manipulation/steering-method/graph.hh>
 #include <pinocchio/spatial/se3.hpp>
 
 namespace pyhpp {
 namespace manipulation {
 
-typedef hpp::manipulation::size_type size_type;
-typedef hpp::manipulation::value_type value_type;
-typedef hpp::manipulation::graph::GraphComponent GraphComponent;
-typedef hpp::manipulation::graph::GraphComponentPtr_t GraphComponentPtr_t;
-typedef hpp::manipulation::ProblemPtr_t ProblemPtr_t;
-typedef hpp::manipulation::graph::Edge Edge;
-typedef hpp::manipulation::graph::EdgePtr_t EdgePtr_t;
-typedef hpp::manipulation::graph::State State;
-typedef hpp::manipulation::graph::StatePtr_t StatePtr_t;
+// =============================================================================
+// Utility functions
+// =============================================================================
 
-template <typename T>
-std::string toStr() {
-  return typeid(T).name();
-}
-template <>
-std::string toStr<hpp::manipulation::graph::State>() {
-  return "State";
-}
-template <>
-std::string toStr<hpp::manipulation::graph::Edge>() {
-  return "Transition";
-}
-template <>
-std::string toStr<hpp::manipulation::graph::Graph>() {
-  return "Graph";
-}
-template <>
-std::string toStr<hpp::manipulation::graph::LevelSetEdge>() {
-  return "LevelSetTransition";
-}
-template <>
-std::string toStr<hpp::manipulation::graph::WaypointEdge>() {
-  return "WaypointTransition";
-}
+std::vector<std::vector<int>> matrixToVectorVector(
+    const Eigen::Ref<const Eigen::Matrix<double, -1, -1>>& input) {
+  std::vector<std::vector<int>> result;
+  result.reserve(input.rows());
 
-template <typename T>
-std::shared_ptr<T> Graph::getComp(const std::string& name) {
-  std::shared_ptr<T> comp;
-  try {
-    auto it(id.find(name));
-    if (it == id.end()) {
-      std::stringstream ss;
-      ss << "\"" << name << "\" is not a " << toStr<T>();
-      throw std::logic_error(ss.str().c_str());
+  for (int i = 0; i < input.rows(); ++i) {
+    std::vector<int> row;
+    row.reserve(input.cols());
+    for (int j = 0; j < input.cols(); ++j) {
+      row.push_back(static_cast<int>(input(i, j)));
     }
-    comp = HPP_DYNAMIC_PTR_CAST(T, obj->get(it->second).lock());
-  } catch (std::out_of_range& e) {
-    throw std::logic_error(e.what());
+    result.push_back(std::move(row));
   }
-  if (!comp) {
-    std::stringstream ss;
-    ss << "\"" << name << "\" is not a " << toStr<T>();
-    throw std::logic_error(ss.str().c_str());
-  }
-  return comp;
+  return result;
 }
 
-// Wrapper class to hpp::manipulation::graph::Graph
-//
-// Boost python does not correctly handle weak pointers. To overcome this
-// limitation, we create a wrapper class and bind this class with boost python
-// instead of the original class.
-Graph::Graph(const hpp::manipulation::graph::GraphPtr_t& object)
+// =============================================================================
+// Wrapper class constructors
+// =============================================================================
+
+PyWState::PyWState(const StatePtr_t& state) : obj(state) {}
+
+PyWEdge::PyWEdge(const EdgePtr_t& edge) : obj(edge) {}
+
+PyWGraph::PyWGraph(const hpp::manipulation::graph::GraphPtr_t& object)
     : obj(object) {}
-Graph::Graph(const std::string& name, const Device& d,
-             const ProblemPtr_t& problem)
-    : obj(hpp::manipulation::graph::Graph::create(name, d.obj, problem)) {}
 
-std::string Graph::name() const { return obj->name(); }
+PyWGraph::PyWGraph(const std::string& name, const PyWDevicePtr_t& d,
+                   const PyWProblemPtr_t& problem)
+    : obj(hpp::manipulation::graph::Graph::create(name, d->obj, problem->obj)) {}
 
-std::size_t Graph::createState(const std::string& nodeName, bool waypoint,
-                               int priority) {
-  hpp::manipulation::graph::GraphPtr_t graph = obj;
-  if (graph->stateSelector()) {
+// =============================================================================
+// Configuration methods
+// =============================================================================
+
+void PyWGraph::maxIterations(size_type iterations) {
+  obj->maxIterations(iterations);
+}
+
+size_type PyWGraph::maxIterations() const {
+  return obj->maxIterations();
+}
+
+void PyWGraph::errorThreshold(const value_type& threshold) {
+  obj->errorThreshold(threshold);
+}
+
+value_type PyWGraph::errorThreshold() const {
+  return obj->errorThreshold();
+}
+
+// =============================================================================
+// Graph construction
+// =============================================================================
+
+PyWStatePtr_t PyWGraph::createState(const std::string& nodeName, bool waypoint,
+                                     int priority) {
+  if (obj->stateSelector()) {
     hpp::manipulation::graph::StatePtr_t state =
-        graph->stateSelector()->createState(nodeName, waypoint, priority);
-    id[nodeName] = state->id();
-    return state->id();
+        obj->stateSelector()->createState(nodeName, waypoint, priority);
+    return std::shared_ptr<PyWState>(new PyWState(state));
   } else {
     throw std::logic_error("Graph has no state selector.");
   }
 }
 
-std::size_t Graph::createTransition(const std::string& nodeFrom,
-                                    const std::string& nodeTo,
-                                    const std::string& transitionName, int w,
-                                    const std::string& isInState) {
+PyWEdgePtr_t PyWGraph::createTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo,
+                                  const std::string& transitionName, int w,
+                                  PyWStatePtr_t isInState) {
   using namespace hpp::manipulation::graph;
-  StatePtr_t from = getComp<State>(nodeFrom), to = getComp<State>(nodeTo),
-             inState = getComp<State>(isInState);
-
-  EdgePtr_t edge =
-      from->linkTo(transitionName, to, w, (State::EdgeFactory)Edge::create);
-  edge->state(inState);
-
-  return (std::size_t)edge->id();
+  EdgePtr_t edge = nodeFrom->obj->linkTo(
+      transitionName, nodeTo->obj, w, (State::EdgeFactory)Edge::create);
+  edge->state(isInState->obj);
+  return std::shared_ptr<PyWEdge>(new PyWEdge(edge));
 }
 
-void Graph::addNumericalConstraint(const std::string& name,
-                                   const ImplicitPtr_t& constraint) {
-  using namespace hpp::manipulation::graph;
-  GraphComponentPtr_t component = getComp<GraphComponent>(name);
-  component->addNumericalConstraint(constraint);
+PyWEdgePtr_t PyWGraph::createWaypointTransition(PyWStatePtr_t nodeFrom,
+                                           PyWStatePtr_t nodeTo,
+                                           const std::string& edgeName, int nb,
+                                           int w, PyWStatePtr_t isInState) {
+  try {
+    using namespace hpp::manipulation::graph;
+    EdgePtr_t edge_pc = nodeFrom->obj->linkTo(
+        edgeName, nodeTo->obj, w, (State::EdgeFactory)WaypointEdge::create);
+    edge_pc->state(isInState->obj);
+
+    auto waypoint_edge = HPP_DYNAMIC_PTR_CAST(WaypointEdge, edge_pc);
+    waypoint_edge->nbWaypoints(nb);
+
+    return std::shared_ptr<PyWEdge>(new PyWEdge(edge_pc));
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
 }
 
-hpp::constraints::NumericalConstraints_t Graph::getNumericalConstraints(
-    const std::string& name) {
-  using namespace hpp::manipulation::graph;
-  GraphComponentPtr_t component = getComp<GraphComponent>(name);
-  return component->numericalConstraints();
+PyWEdgePtr_t PyWGraph::createLevelSetTransition(PyWStatePtr_t nodeFrom,
+                                           PyWStatePtr_t nodeTo,
+                                           const std::string& edgeName, int w,
+                                           PyWStatePtr_t isInState) {
+  try {
+    using namespace hpp::manipulation::graph;
+    EdgePtr_t edge = nodeFrom->obj->linkTo(
+        edgeName, nodeTo->obj, w, (State::EdgeFactory)LevelSetEdge::create);
+    edge->state(isInState->obj);
+    return std::shared_ptr<PyWEdge>(new PyWEdge(edge));
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
 }
 
-std::tuple<bool, Configuration_t, value_type> Graph::applyStateConstraints(
-    const std::string& nodeName, ConfigurationIn_t input) {
+// =============================================================================
+// Edge/State management
+// =============================================================================
+
+void PyWGraph::setContainingNode(PyWEdgePtr_t edge, PyWStatePtr_t state) {
+  try {
+    edge->obj->state(state->obj);
+  } catch (std::exception& err) {
+    throw std::logic_error(err.what());
+  }
+}
+
+std::string PyWGraph::getContainingNode(PyWEdgePtr_t edge) {
+  try {
+    return edge->obj->state()->name();
+  } catch (std::exception& err) {
+    throw std::logic_error(err.what());
+  }
+}
+
+void PyWGraph::setShort(PyWEdgePtr_t edge, bool isShort) {
+  try {
+    edge->obj->setShort(isShort);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+bool PyWGraph::isShort(PyWEdgePtr_t edge) {
+  try {
+    return edge->obj->isShort();
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+void PyWGraph::getNodesConnectedByTransition(PyWEdgePtr_t edge,
+                                        std::string& nodeFrom,
+                                        std::string& nodeTo) {
+  try {
+    nodeFrom = edge->obj->stateFrom()->name();
+    nodeTo = edge->obj->stateTo()->name();
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+void PyWGraph::setWeight(PyWEdgePtr_t edge, int weight) {
+  try {
+    edge->obj->stateFrom()->updateWeight(edge->obj, weight);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+size_t PyWGraph::getWeight(PyWEdgePtr_t edge) {
+  try {
+    return edge->obj->stateFrom()->getWeight(edge->obj);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+// =============================================================================
+// State queries
+// =============================================================================
+
+std::string PyWGraph::getState(ConfigurationIn_t input) {
+  try {
+    hpp::manipulation::graph::StatePtr_t state = obj->getState(input);
+    return state->name();
+  } catch (std::exception& e) {
+    throw std::logic_error(e.what());
+  }
+}
+
+// =============================================================================
+// Constraint management
+// =============================================================================
+
+void PyWGraph::addNumericalConstraint(PyWStatePtr_t node,
+                                       const ImplicitPtr_t& constraint) {
+  node->obj->addNumericalConstraint(constraint);
+}
+
+void PyWGraph::addNumericalConstraints(
+    PyWStatePtr_t component, const boost::python::list& py_constraints) {
+  auto constraints =
+      extract_vector<std::shared_ptr<hpp::constraints::Implicit>>(
+          py_constraints);
+  if (constraints.size() > 0) {
+    try {
+      for (size_t i = 0; i < constraints.size(); ++i) {
+        component->obj->addNumericalConstraint(constraints[i]);
+      }
+    } catch (std::exception& err) {
+      throw std::logic_error(err.what());
+    }
+  }
+}
+
+void PyWGraph::addNumericalConstraintsForPath(
+    PyWStatePtr_t component, const boost::python::list& py_constraints) {
+  auto constraints =
+      extract_vector<std::shared_ptr<hpp::constraints::Implicit>>(
+          py_constraints);
+  if (constraints.size() > 0) {
+    try {
+      for (size_t i = 0; i < constraints.size(); ++i) {
+        component->obj->addNumericalConstraintForPath(constraints[i]);
+      }
+    } catch (std::exception& err) {
+      throw std::logic_error(err.what());
+    }
+  }
+}
+
+boost::python::list PyWGraph::getNumericalConstraints(PyWStatePtr_t component) {
+  return to_python_list(component->obj->numericalConstraints());
+}
+
+void PyWGraph::resetConstraints(PyWStatePtr_t component) {
+  component->obj->resetNumericalConstraints();
+}
+
+void PyWGraph::registerConstraints(const ImplicitPtr_t& constraint,
+                                    const ImplicitPtr_t& complement,
+                                    const ImplicitPtr_t& both) {
+  try {
+    obj->registerConstraints(constraint, complement, both);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+// =============================================================================
+// Configuration error checking
+// =============================================================================
+
+bool PyWGraph::getConfigErrorForState(PyWStatePtr_t component,
+                                       ConfigurationIn_t input,
+                                       hpp::core::vector_t& error) {
+  try {
+    return obj->getConfigErrorForState(input, component->obj, error);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+bool PyWGraph::getConfigErrorForTransition(PyWEdgePtr_t edge,
+                                      ConfigurationIn_t input,
+                                      hpp::core::vector_t& error) {
+  try {
+    // Check if steering method is properly initialized
+    if (!edge->obj->parentGraph()->problem()->manipulationSteeringMethod() ||
+        !edge->obj->parentGraph()
+             ->problem()
+             ->manipulationSteeringMethod()
+             ->innerSteeringMethod()) {
+      throw std::logic_error("Could not initialize the steering method.");
+    }
+    return obj->getConfigErrorForEdge(input, edge->obj, error);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+bool PyWGraph::getConfigErrorForTransitionLeaf(ConfigurationIn_t leafConfig,
+                                          ConfigurationIn_t config,
+                                          const PyWEdgePtr_t& edge,
+                                          hpp::core::vector_t& error) const {
+  return obj->getConfigErrorForEdgeLeaf(leafConfig, config, edge->obj, error);
+}
+
+bool PyWGraph::getConfigErrorForTransitionTarget(ConfigurationIn_t leafConfig,
+                                            ConfigurationIn_t config,
+                                            const PyWEdgePtr_t& edge,
+                                            hpp::core::vector_t& error) const {
+  return obj->getConfigErrorForEdgeTarget(leafConfig, config, edge->obj, error);
+}
+
+// =============================================================================
+// Constraint application
+// =============================================================================
+
+ConstraintResult PyWGraph::applyStateConstraints(PyWStatePtr_t state,
+                                                  ConfigurationIn_t input) {
   using namespace hpp::manipulation;
-  // Recover state from name
-  graph::StatePtr_t state = getComp<graph::State>(nodeName);
-  ConstraintSetPtr_t constraint(state->configConstraint());
+  ConstraintSetPtr_t constraint(state->obj->configConstraint());
   value_type residualError(std::numeric_limits<value_type>::quiet_NaN());
   Configuration_t output(input);
   bool success(constraint->apply(output));
+
   if (hpp::core::ConfigProjectorPtr_t configProjector =
           constraint->configProjector()) {
     residualError = configProjector->residualError();
   }
-  return std::make_tuple(success, output, residualError);
+  return ConstraintResult(success, output, residualError);
 }
 
-std::tuple<bool, Configuration_t, value_type> Graph::applyLeafConstraints(
-    const std::string& transitionName, ConfigurationIn_t q_rhs,
-    ConfigurationIn_t input) {
+ConstraintResult PyWGraph::applyLeafConstraints(PyWEdgePtr_t transition,
+                                                 ConfigurationIn_t q_rhs,
+                                                 ConfigurationIn_t input) {
   using namespace hpp::manipulation;
-  // Recover state from name
-  graph::EdgePtr_t transition = getComp<graph::Edge>(transitionName);
-  ConstraintSetPtr_t constraint(transition->pathConstraint());
+  ConstraintSetPtr_t constraint(transition->obj->pathConstraint());
   value_type residualError(std::numeric_limits<value_type>::quiet_NaN());
   Configuration_t output(input);
   bool success(true);
+
   if (constraint->configProjector()) {
     constraint->configProjector()->rightHandSideFromConfig(q_rhs);
     success = constraint->apply(output);
     residualError = constraint->configProjector()->residualError();
-  } else {
-    residualError = std::numeric_limits<value_type>::quiet_NaN();
   }
-  return std::make_tuple(success, output, residualError);
+  return ConstraintResult(success, output, residualError);
 }
 
-std::tuple<bool, Configuration_t, value_type> Graph::generateTargetConfig(
-    const std::string& transitionName, ConfigurationIn_t q_rhs,
-    ConfigurationIn_t input) {
+ConstraintResult PyWGraph::generateTargetConfig(PyWEdgePtr_t transition,
+                                                 ConfigurationIn_t q_rhs,
+                                                 ConfigurationIn_t input) {
   using namespace hpp::manipulation;
-  // Recover state from name
-  graph::EdgePtr_t transition = getComp<graph::Edge>(transitionName);
-  ConstraintSetPtr_t constraint(transition->targetConstraint());
+  ConstraintSetPtr_t constraint(transition->obj->targetConstraint());
   value_type residualError(std::numeric_limits<value_type>::quiet_NaN());
   Configuration_t output(input);
   bool success(true);
+
   if (constraint->configProjector()) {
     constraint->configProjector()->rightHandSideFromConfig(q_rhs);
     success = constraint->apply(output);
     residualError = constraint->configProjector()->residualError();
-  } else {
-    residualError = std::numeric_limits<value_type>::quiet_NaN();
   }
-  return std::make_tuple(success, output, residualError);
+  return ConstraintResult(success, output, residualError);
 }
+
+// =============================================================================
+// Level set edges
+// =============================================================================
+
+void PyWGraph::addLevelSetFoliation(PyWEdgePtr_t edge,
+                                     const boost::python::list& condNC,
+                                     const boost::python::list& paramNC) {
+  try {
+    using namespace hpp::manipulation::graph;
+    auto levelSetEdge = HPP_DYNAMIC_PTR_CAST(LevelSetEdge, edge->obj);
+    if (!levelSetEdge) {
+      throw std::logic_error("Edge is not a LevelSetEdge");
+    }
+
+    auto condConstraints = extract_vector<ImplicitPtr_t>(condNC);
+    auto paramConstraints = extract_vector<ImplicitPtr_t>(paramNC);
+
+    for (const auto& constraint : condConstraints) {
+      levelSetEdge->insertConditionConstraint(constraint);
+    }
+    for (const auto& constraint : paramConstraints) {
+      levelSetEdge->insertParamConstraint(constraint);
+    }
+  } catch (std::exception& err) {
+    throw std::logic_error(err.what());
+  }
+}
+
+// =============================================================================
+// Security margins and collision
+// =============================================================================
+
+boost::python::list PyWGraph::getSecurityMarginMatrixForTransition(
+    PyWEdgePtr_t edge) {
+  try {
+    std::vector<std::vector<int>> matrix =
+        matrixToVectorVector(edge->obj->securityMargins());
+
+    boost::python::list result;
+    for (const auto& row : matrix) {
+      result.append(to_python_list(row));
+    }
+    return result;
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+void PyWGraph::setSecurityMarginForTransition(PyWEdgePtr_t edge, const char* joint1,
+                                         const char* joint2, double margin) {
+  using namespace hpp::manipulation;
+  try {
+    JointPtr_t j1(obj->robot()->getJointByName(joint1));
+    JointPtr_t j2(obj->robot()->getJointByName(joint2));
+    
+    size_type i1 = j1 ? j1->index() : 0;
+    size_type i2 = j2 ? j2->index() : 0;
+    
+    edge->obj->securityMarginForPair(i1, i2, margin);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+boost::python::list PyWGraph::getRelativeMotionMatrix(PyWEdgePtr_t edge) {
+  try {
+    Eigen::MatrixXi intMatrix = edge->obj->relativeMotion().cast<int>();
+
+    std::vector<std::vector<int>> matrix;
+    matrix.reserve(intMatrix.rows());
+
+    for (int i = 0; i < intMatrix.rows(); ++i) {
+      std::vector<int> row;
+      row.reserve(intMatrix.cols());
+      for (int j = 0; j < intMatrix.cols(); ++j) {
+        row.push_back(intMatrix(i, j));
+      }
+      matrix.push_back(std::move(row));
+    }
+
+    boost::python::list result;
+    for (const auto& row : matrix) {
+      result.append(to_python_list(row));
+    }
+    return result;
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+void PyWGraph::removeCollisionPairFromTransition(PyWEdgePtr_t edge,
+                                            const char* joint1,
+                                            const char* joint2) {
+  try {
+    using hpp::core::RelativeMotion;
+    RelativeMotion::matrix_type m(edge->obj->relativeMotion());
+    DevicePtr_t robot = obj->robot();
+
+    auto j1 = robot->getJointByName(joint1);
+    auto j2 = robot->getJointByName(joint2);
+
+    hpp::manipulation::JointIndex i1 = j1->index();
+    hpp::manipulation::JointIndex i2 = j2->index();
+
+    m(i1, i2) = m(i2, i1) = RelativeMotion::Constrained;
+    edge->obj->relativeMotion(m);
+  } catch (std::exception& err) {
+    throw std::logic_error(err.what());
+  }
+}
+
+// =============================================================================
+// Subgraph management
+// =============================================================================
+
+void PyWGraph::createSubGraph(const char* subgraphName,
+                               hpp::core::RoadmapPtr_t roadmap) {
+  using namespace hpp::manipulation;
+  try {
+    graph::GuidedStateSelectorPtr_t ns =
+        graph::GuidedStateSelector::create(subgraphName, roadmap);
+    obj->stateSelector(ns);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+void PyWGraph::setTargetNodeList(const boost::python::list& py_nodes) {
+  using namespace hpp::manipulation;
+  auto nodes = extract_vector<PyWStatePtr_t>(py_nodes);
+  graph::GuidedStateSelectorPtr_t ns =
+      HPP_DYNAMIC_PTR_CAST(graph::GuidedStateSelector, obj->stateSelector());
+  if (!ns) {
+    throw std::logic_error(
+        "The state selector is not of type GuidedStateSelector.");
+  }
+  
+  try {
+    graph::States_t nl;
+    for (size_t i = 0; i < nodes.size(); ++i) {
+      nl.push_back(nodes[i]->obj);
+    }
+    ns->setStateList(nl);
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+// =============================================================================
+// Display and debugging
+// =============================================================================
+
+std::string PyWGraph::displayStateConstraints(PyWStatePtr_t state) {
+  using namespace hpp::manipulation;
+  try {
+    ConstraintSetPtr_t cs(obj->configConstraint(state->obj));
+    std::ostringstream oss;
+    oss << (*cs);
+    return oss.str();
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+std::string PyWGraph::displayTransitionConstraints(PyWEdgePtr_t edge) {
+  using namespace hpp::manipulation;
+  try {
+    ConstraintSetPtr_t cs(obj->pathConstraint(edge->obj));
+    std::ostringstream oss;
+    oss << (*cs);
+    return oss.str();
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+std::string PyWGraph::displayTransitionTargetConstraints(PyWEdgePtr_t edge) {
+  using namespace hpp::manipulation;
+  try {
+    ConstraintSetPtr_t cs(obj->targetConstraint(edge->obj));
+    std::ostringstream oss;
+    oss << (*cs);
+    return oss.str();
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+void PyWGraph::display(const char* filename) {
+  try {
+    std::ofstream dotfile;
+    dotfile.open(filename);
+    obj->dotPrint(dotfile);
+    dotfile.close();
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+void PyWGraph::initialize() {
+  try {
+    obj->initialize();
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+// =============================================================================
+// Boost.Python bindings
+// =============================================================================
 
 using namespace boost::python;
 
 void exposeGraph() {
-  class_<Graph>("Graph",
-                init<const std::string&, const Device&, const ProblemPtr_t&>())
-      .def_readonly("name", &Graph::name)
-      .def("createState", &Graph::createState)
-      .def("createTransition", &Graph::createTransition)
-      .def("addNumericalConstraint", &Graph::addNumericalConstraint)
-      .def("getNumericalConstraints", &Graph::getNumericalConstraints)
-      .def("applyStateConstraints", &Graph::applyStateConstraints)
-      .def("applyLeafConstraints", &Graph::applyLeafConstraints)
-      .def("generateTargetConfig", &Graph::generateTargetConfig);
+  class_<PyWState, PyWStatePtr_t>("State", no_init);
+  
+  class_<PyWEdge, PyWEdgePtr_t>("Transition", no_init);
+
+  class_<PyWGraph>("Graph", init<const std::string&, const PyWDevicePtr_t&,
+                                 const PyWProblemPtr_t&>())
+
+      // Configuration methods
+      .PYHPP_DEFINE_GETTER_SETTER(PyWGraph, maxIterations, hpp::manipulation::size_type)
+      .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(PyWGraph, errorThreshold, hpp::manipulation::value_type)
+
+      // Graph construction
+      .PYHPP_DEFINE_METHOD(PyWGraph, createState)
+      .PYHPP_DEFINE_METHOD(PyWGraph, createTransition)
+      .PYHPP_DEFINE_METHOD(PyWGraph, createWaypointTransition)
+      .PYHPP_DEFINE_METHOD(PyWGraph, createLevelSetTransition)
+
+      // Transition/State management
+      .PYHPP_DEFINE_METHOD(PyWGraph, setContainingNode)
+      .PYHPP_DEFINE_METHOD(PyWGraph, getContainingNode)
+      .PYHPP_DEFINE_METHOD(PyWGraph, setShort)
+      .PYHPP_DEFINE_METHOD(PyWGraph, isShort)
+      .PYHPP_DEFINE_METHOD(PyWGraph, getNodesConnectedByTransition)
+      .PYHPP_DEFINE_METHOD(PyWGraph, setWeight)
+      .PYHPP_DEFINE_METHOD(PyWGraph, getWeight)
+
+      // State queries
+      .PYHPP_DEFINE_METHOD(PyWGraph, getState)
+
+      // Constraint management
+      .PYHPP_DEFINE_METHOD(PyWGraph, addNumericalConstraint)
+      .PYHPP_DEFINE_METHOD(PyWGraph, addNumericalConstraints)
+      .PYHPP_DEFINE_METHOD(PyWGraph, addNumericalConstraintsForPath)
+      .PYHPP_DEFINE_METHOD(PyWGraph, getNumericalConstraints)
+      .PYHPP_DEFINE_METHOD(PyWGraph, resetConstraints)
+      .PYHPP_DEFINE_METHOD(PyWGraph, registerConstraints)
+
+      // Configuration error checking
+      .PYHPP_DEFINE_METHOD(PyWGraph, getConfigErrorForState)
+      .PYHPP_DEFINE_METHOD(PyWGraph, getConfigErrorForTransition)
+      .PYHPP_DEFINE_METHOD(PyWGraph, getConfigErrorForTransitionLeaf)
+      .PYHPP_DEFINE_METHOD(PyWGraph, getConfigErrorForTransitionTarget)
+
+      // Constraint application
+      .PYHPP_DEFINE_METHOD(PyWGraph, applyStateConstraints)
+      .PYHPP_DEFINE_METHOD(PyWGraph, applyLeafConstraints)
+      .PYHPP_DEFINE_METHOD(PyWGraph, generateTargetConfig)
+
+      // Level set edges
+      .PYHPP_DEFINE_METHOD(PyWGraph, addLevelSetFoliation)
+
+      // Security margins and collision
+      .PYHPP_DEFINE_METHOD(PyWGraph, getSecurityMarginMatrixForTransition)
+      .PYHPP_DEFINE_METHOD(PyWGraph, setSecurityMarginForTransition)
+      .PYHPP_DEFINE_METHOD(PyWGraph, getRelativeMotionMatrix)
+      .PYHPP_DEFINE_METHOD(PyWGraph, removeCollisionPairFromTransition)
+
+      // Subgraph management
+      .PYHPP_DEFINE_METHOD(PyWGraph, createSubGraph)
+      .PYHPP_DEFINE_METHOD(PyWGraph, setTargetNodeList)
+
+      // Display and debugging
+      .PYHPP_DEFINE_METHOD(PyWGraph, displayStateConstraints)
+      .PYHPP_DEFINE_METHOD(PyWGraph, displayTransitionConstraints)
+      .PYHPP_DEFINE_METHOD(PyWGraph, displayTransitionTargetConstraints)
+      .PYHPP_DEFINE_METHOD(PyWGraph, display)
+
+      // Initialization
+      .PYHPP_DEFINE_METHOD(PyWGraph, initialize);
+
+  class_<ConstraintResult>("ConstraintResult")
+      .def_readwrite("success", &ConstraintResult::success)
+      .def_readwrite("configuration", &ConstraintResult::configuration)
+      .def_readwrite("error", &ConstraintResult::error);
 }
+
 }  // namespace manipulation
 }  // namespace pyhpp

--- a/src/pyhpp/manipulation/graph.cc
+++ b/src/pyhpp/manipulation/graph.cc
@@ -39,7 +39,9 @@
 #include <hpp/manipulation/graph/state.hh>
 #include <hpp/manipulation/steering-method/graph.hh>
 #include <pinocchio/spatial/se3.hpp>
-
+#include <hpp/constraints/differentiable-function.hh>
+#include <hpp/constraints/convex-shape-contact.hh>
+#include <hpp/constraints/explicit/convex-shape-contact.hh>
 namespace {
 
     const char* DOC_CREATESTATE = 
@@ -100,14 +102,21 @@ namespace {
     const char* DOC_ADDNUMERICALCONSTRAINT = 
         "Add a numerical constraint to a state.";
 
-    const char* DOC_ADDNUMERICALCONSTRAINTS = 
+    const char* DOC_ADDNUMERICALCONSTRAINTSTOSTATE = 
         "Add numerical constraints to a state.";
+        
+    const char* DOC_ADDNUMERICALCONSTRAINTSTOTRANSITION = 
+        "Add numerical constraints to a TRANSITION.";
 
     const char* DOC_ADDNUMERICALCONSTRAINTSFORPATH = 
         "Add numerical constraints for path to a state.";
 
-    const char* DOC_GETNUMERICALCONSTRAINTS = 
+    const char* DOC_GETNUMERICALCONSTRAINTSFORSTATE = 
         "Get numerical constraints of a state.";
+    const char* DOC_GETNUMERICALCONSTRAINTSFOREDGE = 
+        "Get numerical constraints of an edge.";
+    const char* DOC_GETNUMERICALCONSTRAINTSFORGRAPH = 
+        "Get numerical constraints of the graph.";
 
     const char* DOC_RESETCONSTRAINTS = 
         "Reset constraints of a state.";
@@ -190,6 +199,19 @@ namespace {
         "Initialize the graph. "
         "Performs final initialization of the constraint graph.";
 
+
+    const char* DOC_SETWAYPOINT = 
+          "Set waypoint configuration for a waypoint transition. "
+          "Configures which edge and state to use at the specified waypoint index.";
+
+    const char* DOC_CREATEPLACEMENTCONSTRAINT = 
+      "Create placement constraint between object surfaces and environment surfaces. "
+      "Creates constraints that ensure proper contact between object and environment.";
+
+    const char* DOC_CREATEPREPLACEMENTCONSTRAINT = 
+      "Create pre-placement constraint with specified width margin. "
+      "Used for approaching placement configurations before final placement.";
+
 }
 
 namespace pyhpp {
@@ -228,7 +250,7 @@ PyWGraph::PyWGraph(const hpp::manipulation::graph::GraphPtr_t& object)
 
 PyWGraph::PyWGraph(const std::string& name, const PyWDevicePtr_t& d,
                    const PyWProblemPtr_t& problem)
-    : obj(hpp::manipulation::graph::Graph::create(name, d->obj, problem->obj)) {}
+    : obj(hpp::manipulation::graph::Graph::create(name, d->obj, problem->obj)), robot(d), problem(problem) {}
 
 // =============================================================================
 // Configuration methods
@@ -275,23 +297,46 @@ PyWEdgePtr_t PyWGraph::createTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t no
   return std::shared_ptr<PyWEdge>(new PyWEdge(edge));
 }
 
+// Updated createWaypointTransition method
 PyWEdgePtr_t PyWGraph::createWaypointTransition(PyWStatePtr_t nodeFrom,
-                                           PyWStatePtr_t nodeTo,
-                                           const std::string& edgeName, int nb,
-                                           int w, PyWStatePtr_t isInState) {
-  try {
-    using namespace hpp::manipulation::graph;
-    EdgePtr_t edge_pc = nodeFrom->obj->linkTo(
-        edgeName, nodeTo->obj, w, (State::EdgeFactory)WaypointEdge::create);
-    edge_pc->state(isInState->obj);
+                                                PyWStatePtr_t nodeTo,
+                                                const std::string& edgeName, 
+                                                int nb,
+                                                int w, 
+                                                PyWStatePtr_t isInState,
+                                                bool automaticBuilder) {
+    try {
+        using namespace hpp::manipulation::graph;
+        EdgePtr_t edge_pc = nodeFrom->obj->linkTo(
+            edgeName, nodeTo->obj, w, (State::EdgeFactory)WaypointEdge::create);
+        edge_pc->state(isInState->obj);
 
-    auto waypoint_edge = HPP_DYNAMIC_PTR_CAST(WaypointEdge, edge_pc);
-    waypoint_edge->nbWaypoints(nb);
+        auto waypoint_edge = HPP_DYNAMIC_PTR_CAST(WaypointEdge, edge_pc);
+        waypoint_edge->nbWaypoints(nb);
 
-    return std::shared_ptr<PyWEdge>(new PyWEdge(edge_pc));
-  } catch (const std::exception& exc) {
-    throw std::logic_error(exc.what());
-  }
+        if (automaticBuilder) {
+            PyWStatePtr_t previous = nodeFrom;
+            
+            for (int i = 0; i < nb; ++i) {
+                std::string waypoint_state_name = edgeName + "_n" + std::to_string(i);
+                std::string waypoint_edge_name = edgeName + "_e" + std::to_string(i);
+                
+                PyWStatePtr_t waypoint_state = createState(waypoint_state_name, true, 0);
+                
+                PyWEdgePtr_t waypoint_individual_edge = createTransition(
+                    previous, waypoint_state, waypoint_edge_name, -1, isInState
+                );
+                
+                waypoint_edge->setWaypoint(i, waypoint_individual_edge->obj, waypoint_state->obj);
+                
+                previous = waypoint_state;
+            }
+        }
+        return std::shared_ptr<PyWEdge>(new PyWEdge(edge_pc));
+        
+    } catch (const std::exception& exc) {
+        throw std::logic_error(exc.what());
+    }
 }
 
 PyWEdgePtr_t PyWGraph::createLevelSetTransition(PyWStatePtr_t nodeFrom,
@@ -372,6 +417,31 @@ size_t PyWGraph::getWeight(PyWEdgePtr_t edge) {
   }
 }
 
+void PyWGraph::setWaypoint(PyWEdgePtr_t waypointEdge, int index, 
+                           PyWEdgePtr_t edge, PyWStatePtr_t state) {
+    try {
+        using namespace hpp::manipulation::graph;
+        
+        // Cast to WaypointEdge
+        auto waypoint_edge = HPP_DYNAMIC_PTR_CAST(WaypointEdge, waypointEdge->obj);
+        if (!waypoint_edge) {
+            throw std::logic_error("Edge is not a WaypointEdge");
+        }
+        
+        // Validate index
+        if (index < 0 || static_cast<std::size_t>(index) > waypoint_edge->nbWaypoints()) {
+            throw std::logic_error("Invalid waypoint index");
+        }
+        
+        // Set the waypoint
+        waypoint_edge->setWaypoint(index, edge->obj, state->obj);
+        
+    } catch (const std::exception& exc) {
+        throw std::logic_error(exc.what());
+    }
+}
+
+
 // =============================================================================
 // State queries
 // =============================================================================
@@ -394,7 +464,7 @@ void PyWGraph::addNumericalConstraint(PyWStatePtr_t node,
   node->obj->addNumericalConstraint(constraint);
 }
 
-void PyWGraph::addNumericalConstraints(
+void PyWGraph::addNumericalConstraintsToState(
     PyWStatePtr_t component, const boost::python::list& py_constraints) {
   auto constraints =
       extract_vector<std::shared_ptr<hpp::constraints::Implicit>>(
@@ -403,6 +473,37 @@ void PyWGraph::addNumericalConstraints(
     try {
       for (size_t i = 0; i < constraints.size(); ++i) {
         component->obj->addNumericalConstraint(constraints[i]);
+      }
+    } catch (std::exception& err) {
+      throw std::logic_error(err.what());
+    }
+  }
+}
+
+void PyWGraph::addNumericalConstraintsToTransition(
+    PyWEdgePtr_t component, const boost::python::list& py_constraints) {
+  auto constraints =
+      extract_vector<std::shared_ptr<hpp::constraints::Implicit>>(
+          py_constraints);
+  if (constraints.size() > 0) {
+    try {
+      for (size_t i = 0; i < constraints.size(); ++i) {
+        component->obj->addNumericalConstraint(constraints[i]);
+      }
+    } catch (std::exception& err) {
+      throw std::logic_error(err.what());
+    }
+  }
+}
+
+void PyWGraph::addNumericalConstraintsToGraph(const boost::python::list& py_constraints) {
+  auto constraints =
+      extract_vector<std::shared_ptr<hpp::constraints::Implicit>>(
+          py_constraints);
+  if (constraints.size() > 0) {
+    try {
+      for (size_t i = 0; i < constraints.size(); ++i) {
+        obj->addNumericalConstraint(constraints[i]);
       }
     } catch (std::exception& err) {
       throw std::logic_error(err.what());
@@ -426,8 +527,14 @@ void PyWGraph::addNumericalConstraintsForPath(
   }
 }
 
-boost::python::list PyWGraph::getNumericalConstraints(PyWStatePtr_t component) {
+boost::python::list PyWGraph::getNumericalConstraintsForState(PyWStatePtr_t component) {
   return to_python_list(component->obj->numericalConstraints());
+}
+boost::python::list PyWGraph::getNumericalConstraintsForEdge(PyWEdgePtr_t component) {
+  return to_python_list(component->obj->numericalConstraints());
+}
+boost::python::list PyWGraph::getNumericalConstraintsForGraph() {
+  return to_python_list(obj->numericalConstraints());
 }
 
 void PyWGraph::resetConstraints(PyWStatePtr_t component) {
@@ -754,6 +861,162 @@ void PyWGraph::initialize() {
   }
 }
 
+typedef hpp::pinocchio::vector3_t vector3_t; 
+typedef std::vector<vector3_t> Shape_t;
+typedef std::pair<JointPtr_t, Shape_t> JointAndShape_t;
+typedef std::vector<JointAndShape_t> JointAndShapes_t;
+typedef hpp::constraints::ImplicitPtr_t ImplicitPtr_t;
+boost::python::tuple PyWGraph::createPlacementConstraint(const std::string& name,
+                                        const boost::python::list& py_surface1,
+                                        const boost::python::list& py_surface2,
+                                        const value_type& margin = 1e-4) {
+   try {
+       auto surface1 = extract_vector<std::string>(py_surface1);
+       auto surface2 = extract_vector<std::string>(py_surface2);
+
+       bool explicit_(true);
+       if (!robot->obj) throw std::runtime_error("No robot loaded");
+       JointAndShapes_t floorSurfaces, objectSurfaces, l;
+       
+       for (std::vector<std::string>::const_iterator it1 = surface1.begin(); it1 != surface1.end(); ++it1) {
+           if (!robot->obj->jointAndShapes.has(*it1))
+               throw std::runtime_error("First list of triangles not found.");
+           l = robot->obj->jointAndShapes.get(*it1);
+           objectSurfaces.insert(objectSurfaces.end(), l.begin(), l.end());
+           
+           for (auto js : l) {
+               JointPtr_t j(js.first);
+               if ((j->parentJoint()) ||
+                   ((*j->configurationSpace() != *hpp::pinocchio::LiegroupSpace::SE3()) &&
+                    (*j->configurationSpace() != *hpp::pinocchio::LiegroupSpace::R3xSO3()))) {
+                   explicit_ = false;
+               }
+           }
+       }
+
+       for (std::vector<std::string>::const_iterator it2 = surface2.begin(); it2 != surface2.end(); ++it2) {
+           if (robot->obj->jointAndShapes.has(*it2)) {
+               l = robot->obj->jointAndShapes.get(*it2);
+           }
+           else if (problem->jointAndShapes.has(*it2)) {
+               l = problem->jointAndShapes.get(*it2);
+           }
+           else {
+               throw std::runtime_error("Second list of triangles not found.");
+           }
+           floorSurfaces.insert(floorSurfaces.end(), l.begin(), l.end());
+       }
+
+       if (explicit_) {
+           typedef hpp::constraints::explicit_::ConvexShapeContact Constraint_t;
+           Constraint_t::Constraints_t constraints(
+               Constraint_t::createConstraintAndComplement(name, robot->obj, floorSurfaces,
+                                                           objectSurfaces, margin));
+           
+           assert(hpp::dynamic_pointer_cast<hpp::constraints::ConvexShapeContact>(
+               std::get<0>(constraints)->functionPtr()));
+           hpp::constraints::ConvexShapeContactPtr_t contactFunction(
+               hpp::static_pointer_cast<hpp::constraints::ConvexShapeContact>(
+                   std::get<0>(constraints)->functionPtr()));
+           contactFunction->setNormalMargin(margin);
+           
+           return boost::python::make_tuple(
+               std::get<0>(constraints),
+               std::get<1>(constraints),
+               std::get<2>(constraints)
+           );
+           
+       } else {
+           using hpp::constraints::ComparisonTypes_t;
+           using hpp::constraints::Equality;
+           using hpp::constraints::EqualToZero;
+           using hpp::constraints::Implicit;
+           
+           std::pair<hpp::constraints::ConvexShapeContactPtr_t,
+                     hpp::constraints::ConvexShapeContactComplementPtr_t>
+               functions(hpp::constraints::ConvexShapeContactComplement::createPair(
+                   name, robot->obj, floorSurfaces, objectSurfaces));
+           
+           functions.first->setNormalMargin(margin);
+
+           auto constraint = Implicit::create(functions.first, 5 * EqualToZero);
+           auto complement = Implicit::create(
+               functions.second,
+               ComparisonTypes_t(functions.second->outputSize(), Equality));
+           
+           return boost::python::make_tuple(constraint, complement, boost::python::object());
+       }
+       
+   } catch (const std::exception& exc) {
+       throw std::logic_error(exc.what());
+   }
+}
+
+boost::python::tuple PyWGraph::createPlacementConstraint1(
+    const std::string& name, const boost::python::list& py_surface1,
+    const boost::python::list& py_surface2, const value_type& margin) {
+    return createPlacementConstraint(name, py_surface1, py_surface2, margin);
+}
+boost::python::tuple PyWGraph::createPlacementConstraint2(
+    const std::string& name, const boost::python::list& py_surface1,
+    const boost::python::list& py_surface2) {
+    return createPlacementConstraint(name, py_surface1, py_surface2);
+}
+
+ImplicitPtr_t PyWGraph::createPrePlacementConstraint(const std::string& name,
+                                           const boost::python::list& py_surface1,
+                                           const boost::python::list& py_surface2,
+                                           const value_type& width,
+                                           const value_type& margin= 1e-4) {
+   try {
+       auto surface1 = extract_vector<std::string>(py_surface1);
+       auto surface2 = extract_vector<std::string>(py_surface2);
+
+       if (!robot->obj) throw std::runtime_error("No robot loaded");
+       JointAndShapes_t floorSurfaces, objectSurfaces, l;
+       
+       for (std::vector<std::string>::const_iterator it1 = surface1.begin(); it1 != surface1.end(); ++it1) {
+           if (!robot->obj->jointAndShapes.has(*it1))
+               throw std::runtime_error("First list of triangles not found.");
+           l = robot->obj->jointAndShapes.get(*it1);
+           objectSurfaces.insert(objectSurfaces.end(), l.begin(), l.end());
+       }
+
+       for (std::vector<std::string>::const_iterator it2 = surface2.begin(); it2 != surface2.end(); ++it2) {
+           if (robot->obj->jointAndShapes.has(*it2)) {
+               l = robot->obj->jointAndShapes.get(*it2);
+           }
+           else if (problem->jointAndShapes.has(*it2)) {
+               l = problem->jointAndShapes.get(*it2);
+           }
+           else {
+               throw std::runtime_error("Second list of triangles not found.");
+           }
+           floorSurfaces.insert(floorSurfaces.end(), l.begin(), l.end());
+       }
+
+       hpp::constraints::ConvexShapeContactPtr_t cvxShape(
+           hpp::constraints::ConvexShapeContact::create(name, robot->obj, floorSurfaces,
+                                                        objectSurfaces));
+       cvxShape->setNormalMargin(margin + width);
+       
+       return hpp::constraints::Implicit::create(cvxShape, 5 * hpp::constraints::EqualToZero);
+       
+   } catch (const std::exception& exc) {
+       throw std::logic_error(exc.what());
+   }
+}
+ImplicitPtr_t PyWGraph::createPrePlacementConstraint1(
+    const std::string& name, const boost::python::list& py_surface1,
+    const boost::python::list& py_surface2, const value_type& width, const value_type& margin) {
+    return createPrePlacementConstraint(name, py_surface1, py_surface2, width, margin);
+}
+ImplicitPtr_t PyWGraph::createPrePlacementConstraint2(
+    const std::string& name, const boost::python::list& py_surface1,
+    const boost::python::list& py_surface2, const value_type& width) {
+    return createPrePlacementConstraint(name, py_surface1, py_surface2, width);
+}
+
 // =============================================================================
 // Boost.Python bindings
 // =============================================================================
@@ -768,6 +1031,7 @@ void exposeGraph() {
   class_<PyWGraph>("Graph", init<const std::string&, const PyWDevicePtr_t&,
                                 const PyWProblemPtr_t&>())
 
+      .def_readwrite("robot", &PyWGraph::robot)
       // Configuration methods
       .PYHPP_DEFINE_GETTER_SETTER(PyWGraph, maxIterations, hpp::manipulation::size_type)
       .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(PyWGraph, errorThreshold, hpp::manipulation::value_type)
@@ -786,17 +1050,27 @@ void exposeGraph() {
       .PYHPP_DEFINE_METHOD1(PyWGraph, getNodesConnectedByTransition, DOC_GETNODESCONNECTEDBYTRANSITION)
       .PYHPP_DEFINE_METHOD1(PyWGraph, setWeight, DOC_SETWEIGHT)
       .PYHPP_DEFINE_METHOD1(PyWGraph, getWeight, DOC_GETWEIGHT)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, setWaypoint, DOC_SETWAYPOINT)
 
       // State queries
       .PYHPP_DEFINE_METHOD1(PyWGraph, getState, DOC_GETSTATE)
 
       // Constraint management
       .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraint, DOC_ADDNUMERICALCONSTRAINT)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraints, DOC_ADDNUMERICALCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraintsToState, DOC_ADDNUMERICALCONSTRAINTSTOSTATE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraintsToTransition, DOC_ADDNUMERICALCONSTRAINTSTOTRANSITION)
+      .PYHPP_DEFINE_METHOD(PyWGraph, addNumericalConstraintsToGraph)
       .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraintsForPath, DOC_ADDNUMERICALCONSTRAINTSFORPATH)
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraints, DOC_GETNUMERICALCONSTRAINTS)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraintsForState, DOC_GETNUMERICALCONSTRAINTSFORSTATE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraintsForEdge, DOC_GETNUMERICALCONSTRAINTSFOREDGE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getNumericalConstraintsForGraph, DOC_GETNUMERICALCONSTRAINTSFORGRAPH)
       .PYHPP_DEFINE_METHOD1(PyWGraph, resetConstraints, DOC_RESETCONSTRAINTS)
       .PYHPP_DEFINE_METHOD1(PyWGraph, registerConstraints, DOC_REGISTERCONSTRAINTS)
+
+      .def("createPlacementConstraint", &PyWGraph::createPlacementConstraint1, DOC_CREATEPLACEMENTCONSTRAINT)
+      .def("createPlacementConstraint", &PyWGraph::createPlacementConstraint2, DOC_CREATEPLACEMENTCONSTRAINT)
+      .def("createPrePlacementConstraint", &PyWGraph::createPrePlacementConstraint1, DOC_CREATEPREPLACEMENTCONSTRAINT)
+      .def("createPrePlacementConstraint", &PyWGraph::createPrePlacementConstraint2, DOC_CREATEPREPLACEMENTCONSTRAINT)
 
       // Configuration error checking
       .PYHPP_DEFINE_METHOD1(PyWGraph, getConfigErrorForState, DOC_GETCONFIGERRORFORSTATE)

--- a/src/pyhpp/manipulation/graph.hh
+++ b/src/pyhpp/manipulation/graph.hh
@@ -27,8 +27,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <pyhpp/manipulation/fwd.hh>
 #include <hpp/manipulation/graph/graph.hh>
+#include <pyhpp/manipulation/fwd.hh>
 
 namespace pyhpp {
 namespace manipulation {
@@ -62,7 +62,7 @@ struct PyWState {
 };
 typedef std::shared_ptr<PyWState> PyWStatePtr_t;
 
-/// Python wrapper for Edge  
+/// Python wrapper for Edge
 struct PyWEdge {
   EdgePtr_t obj;
   PyWEdge(const EdgePtr_t& object);
@@ -81,7 +81,7 @@ struct PyWGraph {
 
   // Constructors
   PyWGraph(const GraphPtr_t& object);
-  PyWGraph(const std::string& name, const PyWDevicePtr_t& d, 
+  PyWGraph(const std::string& name, const PyWDevicePtr_t& d,
            const PyWProblemPtr_t& problem);
 
   // Configuration methods
@@ -91,111 +91,116 @@ struct PyWGraph {
   value_type errorThreshold() const;
 
   // Graph construction
-  PyWStatePtr_t createState(const std::string& nodeName, bool waypoint, 
-                           int priority);
+  PyWStatePtr_t createState(const std::string& nodeName, bool waypoint,
+                            int priority);
   PyWEdgePtr_t createTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo,
-                         const std::string& transitionName, int w,
-                         PyWStatePtr_t isInState);
-  PyWEdgePtr_t createWaypointTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo,
-                                 const std::string& edgeName, int nb, int w, 
-                                 PyWStatePtr_t isInState, bool automaticBuilder);
-  PyWEdgePtr_t createLevelSetTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo,
-                                 const std::string& edgeName, int w,
-                                 PyWStatePtr_t isInState);
+                                const std::string& transitionName, int w,
+                                PyWStatePtr_t isInState);
+  PyWEdgePtr_t createWaypointTransition(PyWStatePtr_t nodeFrom,
+                                        PyWStatePtr_t nodeTo,
+                                        const std::string& edgeName, int nb,
+                                        int w, PyWStatePtr_t isInState,
+                                        bool automaticBuilder);
+  PyWEdgePtr_t createLevelSetTransition(PyWStatePtr_t nodeFrom,
+                                        PyWStatePtr_t nodeTo,
+                                        const std::string& edgeName, int w,
+                                        PyWStatePtr_t isInState);
 
   // Edge/State management
   void setContainingNode(PyWEdgePtr_t edge, PyWStatePtr_t node);
   std::string getContainingNode(PyWEdgePtr_t edge);
   void setShort(PyWEdgePtr_t edge, bool isShort);
   bool isShort(PyWEdgePtr_t edge);
-  void getNodesConnectedByTransition(PyWEdgePtr_t edge, std::string& nodeFrom, 
-                              std::string& nodeTo);
+  void getNodesConnectedByTransition(PyWEdgePtr_t edge, std::string& nodeFrom,
+                                     std::string& nodeTo);
   void setWeight(PyWEdgePtr_t edge, int weight);
   size_t getWeight(PyWEdgePtr_t edge);
-  void setWaypoint(PyWEdgePtr_t waypointEdge, int index, 
-                           PyWEdgePtr_t edge, PyWStatePtr_t state);
-  void addNumericalConstraintsToGraph(const boost::python::list& py_constraints);
+  void setWaypoint(PyWEdgePtr_t waypointEdge, int index, PyWEdgePtr_t edge,
+                   PyWStatePtr_t state);
+  void addNumericalConstraintsToGraph(
+      const boost::python::list& py_constraints);
   // State queries
   std::string getState(ConfigurationIn_t input);
 
   // Constraint management
-  void addNumericalConstraint(PyWStatePtr_t node, const ImplicitPtr_t& constraint);
-  void addNumericalConstraintsToState(PyWStatePtr_t component, 
-                              const boost::python::list& py_constraints);
-  void addNumericalConstraintsToTransition(PyWEdgePtr_t component, 
-                              const boost::python::list& py_constraints);
-  void addNumericalConstraintsForPath(PyWStatePtr_t component, 
-                                     const boost::python::list& py_constraints);
+  void addNumericalConstraint(PyWStatePtr_t node,
+                              const ImplicitPtr_t& constraint);
+  void addNumericalConstraintsToState(
+      PyWStatePtr_t component, const boost::python::list& py_constraints);
+  void addNumericalConstraintsToTransition(
+      PyWEdgePtr_t component, const boost::python::list& py_constraints);
+  void addNumericalConstraintsForPath(
+      PyWStatePtr_t component, const boost::python::list& py_constraints);
   void resetConstraints(PyWStatePtr_t component);
   void registerConstraints(const ImplicitPtr_t& constraint,
-                          const ImplicitPtr_t& complement,
-                          const ImplicitPtr_t& both);
+                           const ImplicitPtr_t& complement,
+                           const ImplicitPtr_t& both);
 
-  boost::python::tuple createPlacementConstraint(const std::string& name,
-                                                 const boost::python::list& py_surface1,
-                                                 const boost::python::list& py_surface2,
-                                                 const value_type& margin);
-  ImplicitPtr_t createPrePlacementConstraint(const std::string& name,
-                                                 const boost::python::list& py_surface1,
-                                                 const boost::python::list& py_surface2,
-                                                 const value_type& width,
-                                                 const value_type& margin);
+  boost::python::tuple createPlacementConstraint(
+      const std::string& name, const boost::python::list& py_surface1,
+      const boost::python::list& py_surface2, const value_type& margin);
+  ImplicitPtr_t createPrePlacementConstraint(
+      const std::string& name, const boost::python::list& py_surface1,
+      const boost::python::list& py_surface2, const value_type& width,
+      const value_type& margin);
   boost::python::tuple createPlacementConstraint1(
-    const std::string& name, const boost::python::list& py_surface1,
-    const boost::python::list& py_surface2, const value_type& margin);
-boost::python::tuple createPlacementConstraint2(
-    const std::string& name, const boost::python::list& py_surface1,
-    const boost::python::list& py_surface2);
-ImplicitPtr_t createPrePlacementConstraint1(
-    const std::string& name, const boost::python::list& py_surface1,
-    const boost::python::list& py_surface2, const value_type& width, const value_type& margin);
-ImplicitPtr_t createPrePlacementConstraint2(
-    const std::string& name, const boost::python::list& py_surface1,
-    const boost::python::list& py_surface2, const value_type& width);
+      const std::string& name, const boost::python::list& py_surface1,
+      const boost::python::list& py_surface2, const value_type& margin);
+  boost::python::tuple createPlacementConstraint2(
+      const std::string& name, const boost::python::list& py_surface1,
+      const boost::python::list& py_surface2);
+  ImplicitPtr_t createPrePlacementConstraint1(
+      const std::string& name, const boost::python::list& py_surface1,
+      const boost::python::list& py_surface2, const value_type& width,
+      const value_type& margin);
+  ImplicitPtr_t createPrePlacementConstraint2(
+      const std::string& name, const boost::python::list& py_surface1,
+      const boost::python::list& py_surface2, const value_type& width);
 
-boost::python::list getNumericalConstraintsForState(PyWStatePtr_t component);
-boost::python::list getNumericalConstraintsForEdge(PyWEdgePtr_t component);
-boost::python::list getNumericalConstraintsForGraph();
+  boost::python::list getNumericalConstraintsForState(PyWStatePtr_t component);
+  boost::python::list getNumericalConstraintsForEdge(PyWEdgePtr_t component);
+  boost::python::list getNumericalConstraintsForGraph();
 
   // Configuration error checking
-  bool getConfigErrorForState(PyWStatePtr_t component, ConfigurationIn_t input, 
-                             hpp::core::vector_t& error);
-  bool getConfigErrorForTransition(PyWEdgePtr_t edge, ConfigurationIn_t input, 
-                            hpp::core::vector_t& error);
-  bool getConfigErrorForTransitionLeaf(ConfigurationIn_t leafConfig, 
-                                ConfigurationIn_t config, 
-                                const PyWEdgePtr_t& edge, 
-                                hpp::core::vector_t& error) const;
-  bool getConfigErrorForTransitionTarget(ConfigurationIn_t leafConfig, 
-                                  ConfigurationIn_t config, 
-                                  const PyWEdgePtr_t& edge, 
-                                  hpp::core::vector_t& error) const;
+  bool getConfigErrorForState(PyWStatePtr_t component, ConfigurationIn_t input,
+                              hpp::core::vector_t& error);
+  bool getConfigErrorForTransition(PyWEdgePtr_t edge, ConfigurationIn_t input,
+                                   hpp::core::vector_t& error);
+  bool getConfigErrorForTransitionLeaf(ConfigurationIn_t leafConfig,
+                                       ConfigurationIn_t config,
+                                       const PyWEdgePtr_t& edge,
+                                       hpp::core::vector_t& error) const;
+  bool getConfigErrorForTransitionTarget(ConfigurationIn_t leafConfig,
+                                         ConfigurationIn_t config,
+                                         const PyWEdgePtr_t& edge,
+                                         hpp::core::vector_t& error) const;
 
   // Constraint application
-  ConstraintResult applyStateConstraints(PyWStatePtr_t state, 
+  ConstraintResult applyStateConstraints(PyWStatePtr_t state,
+                                         ConfigurationIn_t input);
+  ConstraintResult applyLeafConstraints(PyWEdgePtr_t transition,
+                                        ConfigurationIn_t q_rhs,
                                         ConfigurationIn_t input);
-  ConstraintResult applyLeafConstraints(PyWEdgePtr_t transition, 
-                                       ConfigurationIn_t q_rhs,
-                                       ConfigurationIn_t input);
-  ConstraintResult generateTargetConfig(PyWEdgePtr_t transition, 
-                                       ConfigurationIn_t q_rhs,
-                                       ConfigurationIn_t input);
+  ConstraintResult generateTargetConfig(PyWEdgePtr_t transition,
+                                        ConfigurationIn_t q_rhs,
+                                        ConfigurationIn_t input);
 
   // Level set edges
-  void addLevelSetFoliation(PyWEdgePtr_t edge, 
-                           const boost::python::list& condNC,
-                           const boost::python::list& paramNC);
+  void addLevelSetFoliation(PyWEdgePtr_t edge,
+                            const boost::python::list& condNC,
+                            const boost::python::list& paramNC);
 
   // Security margins and collision
   boost::python::list getSecurityMarginMatrixForTransition(PyWEdgePtr_t edge);
   void setSecurityMarginForTransition(PyWEdgePtr_t edge, const char* joint1,
-                               const char* joint2, double margin);
+                                      const char* joint2, double margin);
   boost::python::list getRelativeMotionMatrix(PyWEdgePtr_t edge);
-  void removeCollisionPairFromTransition(PyWEdgePtr_t edge, const char* joint1, 
-                                  const char* joint2);
+  void removeCollisionPairFromTransition(PyWEdgePtr_t edge, const char* joint1,
+                                         const char* joint2);
 
   // Subgraph management
-  void createSubGraph(const char* subgraphName, hpp::core::RoadmapPtr_t roadmap);
+  void createSubGraph(const char* subgraphName,
+                      hpp::core::RoadmapPtr_t roadmap);
   void setTargetNodeList(const boost::python::list& nodes);
 
   // Display and debugging

--- a/src/pyhpp/manipulation/graph.hh
+++ b/src/pyhpp/manipulation/graph.hh
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2025, CNRS
-// Authors: Florent Lamiraux
+// Authors: Florent Lamiraux, Paul Sardin
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <pyhpp/manipulation/fwd.hh>
 #include <hpp/manipulation/graph/graph.hh>
 
 namespace pyhpp {
@@ -41,48 +42,140 @@ typedef hpp::manipulation::graph::Edge Edge;
 typedef hpp::manipulation::graph::EdgePtr_t EdgePtr_t;
 typedef hpp::manipulation::graph::State State;
 typedef hpp::manipulation::graph::StatePtr_t StatePtr_t;
+typedef hpp::manipulation::graph::GraphPtr_t GraphPtr_t;
 
-struct Graph {
+/// Result structure for constraint operations
+struct ConstraintResult {
+  bool success;
+  Configuration_t configuration;
+  value_type error;
+
+  ConstraintResult() : success(false), configuration(), error(0.0) {}
+  ConstraintResult(bool s, const Configuration_t& config, value_type err)
+      : success(s), configuration(config), error(err) {}
+};
+
+/// Python wrapper for State
+struct PyWState {
+  StatePtr_t obj;
+  PyWState(const StatePtr_t& object);
+};
+typedef std::shared_ptr<PyWState> PyWStatePtr_t;
+
+/// Python wrapper for Edge  
+struct PyWEdge {
+  EdgePtr_t obj;
+  PyWEdge(const EdgePtr_t& object);
+};
+typedef std::shared_ptr<PyWEdge> PyWEdgePtr_t;
+
+/// Python wrapper for Graph
+struct PyWGraph {
   typedef hpp::constraints::ImplicitPtr_t ImplicitPtr_t;
   typedef hpp::constraints::NumericalConstraints_t NumericalConstraints_t;
-  // Pointer to the underlying object
-  hpp::manipulation::graph::GraphPtr_t obj;
-  // Map from name to id
-  std::map<std::string, std::size_t> id;
-  // Get shared pointer to object from name among (Graph, Node, Edge)
-  template <typename T>
-  std::shared_ptr<T> getComp(const std::string& name);
-  // Constructor with a pointer to underlying graph
-  Graph(const hpp::manipulation::graph::GraphPtr_t& object);
-  // Constructor exposed in python
-  Graph(const std::string& name, const Device& d, const ProblemPtr_t& problem);
-  // Get name of the graph
-  std::string name() const;
-  // Create a state in the graph
-  std::size_t createState(const std::string& nodeName, bool waypoint,
-                          int priority);
-  // Create a transition between two states in the graph
-  std::size_t createTransition(const std::string& nodeFrom,
-                               const std::string& nodeTo,
-                               const std::string& transitionName, int w,
-                               const std::string& isInState);
-  // Add numerical constraints to a graph, a state or a transition
-  void addNumericalConstraint(const std::string& name,
-                              const ImplicitPtr_t& constraint);
-  // Get numerical constraints of a graph, a state or a transition
-  NumericalConstraints_t getNumericalConstraints(const std::string& name);
-  // Project a configuration on a state
-  std::tuple<bool, Configuration_t, value_type> applyStateConstraints(
-      const std::string& nodeName, ConfigurationIn_t input);
-  // Project configuration on the leaf of a transition
-  std::tuple<bool, Configuration_t, value_type> applyLeafConstraints(
-      const std::string& transitionName, ConfigurationIn_t q_rhs,
-      ConfigurationIn_t input);
-  // Project configuration at intersection of a leaf and the goal state of a
-  // trnasition
-  std::tuple<bool, Configuration_t, value_type> generateTargetConfig(
-      const std::string& transitionName, ConfigurationIn_t q_rhs,
-      ConfigurationIn_t input);
-};  // class Graph
+
+  // Member variables
+  GraphPtr_t obj;
+
+  // Constructors
+  PyWGraph(const GraphPtr_t& object);
+  PyWGraph(const std::string& name, const PyWDevicePtr_t& d, 
+           const PyWProblemPtr_t& problem);
+
+  // Configuration methods
+  void maxIterations(size_type iterations);
+  size_type maxIterations() const;
+  void errorThreshold(const value_type& threshold);
+  value_type errorThreshold() const;
+
+  // Graph construction
+  PyWStatePtr_t createState(const std::string& nodeName, bool waypoint, 
+                           int priority);
+  PyWEdgePtr_t createTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo,
+                         const std::string& transitionName, int w,
+                         PyWStatePtr_t isInState);
+  PyWEdgePtr_t createWaypointTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo,
+                                 const std::string& edgeName, int nb, int w, 
+                                 PyWStatePtr_t isInState);
+  PyWEdgePtr_t createLevelSetTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo,
+                                 const std::string& edgeName, int w,
+                                 PyWStatePtr_t isInState);
+
+  // Edge/State management
+  void setContainingNode(PyWEdgePtr_t edge, PyWStatePtr_t node);
+  std::string getContainingNode(PyWEdgePtr_t edge);
+  void setShort(PyWEdgePtr_t edge, bool isShort);
+  bool isShort(PyWEdgePtr_t edge);
+  void getNodesConnectedByTransition(PyWEdgePtr_t edge, std::string& nodeFrom, 
+                              std::string& nodeTo);
+  void setWeight(PyWEdgePtr_t edge, int weight);
+  size_t getWeight(PyWEdgePtr_t edge);
+
+  // State queries
+  std::string getState(ConfigurationIn_t input);
+
+  // Constraint management
+  void addNumericalConstraint(PyWStatePtr_t node, const ImplicitPtr_t& constraint);
+  void addNumericalConstraints(PyWStatePtr_t component, 
+                              const boost::python::list& py_constraints);
+  void addNumericalConstraintsForPath(PyWStatePtr_t component, 
+                                     const boost::python::list& py_constraints);
+  boost::python::list getNumericalConstraints(PyWStatePtr_t component);
+  void resetConstraints(PyWStatePtr_t component);
+  void registerConstraints(const ImplicitPtr_t& constraint,
+                          const ImplicitPtr_t& complement,
+                          const ImplicitPtr_t& both);
+
+  // Configuration error checking
+  bool getConfigErrorForState(PyWStatePtr_t component, ConfigurationIn_t input, 
+                             hpp::core::vector_t& error);
+  bool getConfigErrorForTransition(PyWEdgePtr_t edge, ConfigurationIn_t input, 
+                            hpp::core::vector_t& error);
+  bool getConfigErrorForTransitionLeaf(ConfigurationIn_t leafConfig, 
+                                ConfigurationIn_t config, 
+                                const PyWEdgePtr_t& edge, 
+                                hpp::core::vector_t& error) const;
+  bool getConfigErrorForTransitionTarget(ConfigurationIn_t leafConfig, 
+                                  ConfigurationIn_t config, 
+                                  const PyWEdgePtr_t& edge, 
+                                  hpp::core::vector_t& error) const;
+
+  // Constraint application
+  ConstraintResult applyStateConstraints(PyWStatePtr_t state, 
+                                        ConfigurationIn_t input);
+  ConstraintResult applyLeafConstraints(PyWEdgePtr_t transition, 
+                                       ConfigurationIn_t q_rhs,
+                                       ConfigurationIn_t input);
+  ConstraintResult generateTargetConfig(PyWEdgePtr_t transition, 
+                                       ConfigurationIn_t q_rhs,
+                                       ConfigurationIn_t input);
+
+  // Level set edges
+  void addLevelSetFoliation(PyWEdgePtr_t edge, 
+                           const boost::python::list& condNC,
+                           const boost::python::list& paramNC);
+
+  // Security margins and collision
+  boost::python::list getSecurityMarginMatrixForTransition(PyWEdgePtr_t edge);
+  void setSecurityMarginForTransition(PyWEdgePtr_t edge, const char* joint1,
+                               const char* joint2, double margin);
+  boost::python::list getRelativeMotionMatrix(PyWEdgePtr_t edge);
+  void removeCollisionPairFromTransition(PyWEdgePtr_t edge, const char* joint1, 
+                                  const char* joint2);
+
+  // Subgraph management
+  void createSubGraph(const char* subgraphName, hpp::core::RoadmapPtr_t roadmap);
+  void setTargetNodeList(const boost::python::list& nodes);
+
+  // Display and debugging
+  std::string displayStateConstraints(PyWStatePtr_t state);
+  std::string displayTransitionConstraints(PyWEdgePtr_t edge);
+  std::string displayTransitionTargetConstraints(PyWEdgePtr_t edge);
+  void display(const char* filename);
+
+  // Initialization
+  void initialize();
+};
+
 }  // namespace manipulation
 }  // namespace pyhpp

--- a/src/pyhpp/manipulation/graph.hh
+++ b/src/pyhpp/manipulation/graph.hh
@@ -76,6 +76,8 @@ struct PyWGraph {
 
   // Member variables
   GraphPtr_t obj;
+  PyWDevicePtr_t robot;
+  PyWProblemPtr_t problem;
 
   // Constructors
   PyWGraph(const GraphPtr_t& object);
@@ -96,7 +98,7 @@ struct PyWGraph {
                          PyWStatePtr_t isInState);
   PyWEdgePtr_t createWaypointTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo,
                                  const std::string& edgeName, int nb, int w, 
-                                 PyWStatePtr_t isInState);
+                                 PyWStatePtr_t isInState, bool automaticBuilder);
   PyWEdgePtr_t createLevelSetTransition(PyWStatePtr_t nodeFrom, PyWStatePtr_t nodeTo,
                                  const std::string& edgeName, int w,
                                  PyWStatePtr_t isInState);
@@ -110,21 +112,50 @@ struct PyWGraph {
                               std::string& nodeTo);
   void setWeight(PyWEdgePtr_t edge, int weight);
   size_t getWeight(PyWEdgePtr_t edge);
-
+  void setWaypoint(PyWEdgePtr_t waypointEdge, int index, 
+                           PyWEdgePtr_t edge, PyWStatePtr_t state);
+  void addNumericalConstraintsToGraph(const boost::python::list& py_constraints);
   // State queries
   std::string getState(ConfigurationIn_t input);
 
   // Constraint management
   void addNumericalConstraint(PyWStatePtr_t node, const ImplicitPtr_t& constraint);
-  void addNumericalConstraints(PyWStatePtr_t component, 
+  void addNumericalConstraintsToState(PyWStatePtr_t component, 
+                              const boost::python::list& py_constraints);
+  void addNumericalConstraintsToTransition(PyWEdgePtr_t component, 
                               const boost::python::list& py_constraints);
   void addNumericalConstraintsForPath(PyWStatePtr_t component, 
                                      const boost::python::list& py_constraints);
-  boost::python::list getNumericalConstraints(PyWStatePtr_t component);
   void resetConstraints(PyWStatePtr_t component);
   void registerConstraints(const ImplicitPtr_t& constraint,
                           const ImplicitPtr_t& complement,
                           const ImplicitPtr_t& both);
+
+  boost::python::tuple createPlacementConstraint(const std::string& name,
+                                                 const boost::python::list& py_surface1,
+                                                 const boost::python::list& py_surface2,
+                                                 const value_type& margin);
+  ImplicitPtr_t createPrePlacementConstraint(const std::string& name,
+                                                 const boost::python::list& py_surface1,
+                                                 const boost::python::list& py_surface2,
+                                                 const value_type& width,
+                                                 const value_type& margin);
+  boost::python::tuple createPlacementConstraint1(
+    const std::string& name, const boost::python::list& py_surface1,
+    const boost::python::list& py_surface2, const value_type& margin);
+boost::python::tuple createPlacementConstraint2(
+    const std::string& name, const boost::python::list& py_surface1,
+    const boost::python::list& py_surface2);
+ImplicitPtr_t createPrePlacementConstraint1(
+    const std::string& name, const boost::python::list& py_surface1,
+    const boost::python::list& py_surface2, const value_type& width, const value_type& margin);
+ImplicitPtr_t createPrePlacementConstraint2(
+    const std::string& name, const boost::python::list& py_surface1,
+    const boost::python::list& py_surface2, const value_type& width);
+
+boost::python::list getNumericalConstraintsForState(PyWStatePtr_t component);
+boost::python::list getNumericalConstraintsForEdge(PyWEdgePtr_t component);
+boost::python::list getNumericalConstraintsForGraph();
 
   // Configuration error checking
   bool getConfigErrorForState(PyWStatePtr_t component, ConfigurationIn_t input, 

--- a/src/pyhpp/manipulation/problem.cc
+++ b/src/pyhpp/manipulation/problem.cc
@@ -61,6 +61,13 @@ ConfigurationShooterPtr_t Problem::configurationShooter() const {
   return obj->configurationShooter();
 }
 
+void Problem::initConfig(ConfigurationIn_t inConfig) {
+  obj->initConfig(inConfig);
+}
+
+void Problem::addGoalConfig(ConfigurationIn_t config) {
+  obj->addGoalConfig(config);
+}
 
 // PathValidationPtr_t Problem::pathValidation() const {
 //     return obj->pathValidation();
@@ -99,6 +106,8 @@ void exposeProblem() {
   .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(Problem, constraintGraph, PyWGraphPtr_t)
   .PYHPP_DEFINE_METHOD(Problem, checkProblem)
   .PYHPP_DEFINE_METHOD(Problem, configurationShooter)
+  .PYHPP_DEFINE_METHOD(Problem, initConfig)
+  .PYHPP_DEFINE_METHOD(Problem, addGoalConfig)
   // .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(Problem, pathValidation, PathValidationPtr_t)
   // .PYHPP_DEFINE_METHOD(Problem, manipulationSteeringMethod)
   // .PYHPP_DEFINE_METHOD(Problem, pathValidationFactory)

--- a/src/pyhpp/manipulation/problem.cc
+++ b/src/pyhpp/manipulation/problem.cc
@@ -27,10 +27,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <boost/python.hpp>
-#include <../src/pyhpp/manipulation/problem.hh>
 #include <../src/pyhpp/manipulation/device.hh>
 #include <../src/pyhpp/manipulation/graph.hh>
+#include <../src/pyhpp/manipulation/problem.hh>
+#include <boost/python.hpp>
 #include <hpp/core/problem.hh>
 
 using namespace boost::python;
@@ -39,23 +39,22 @@ namespace pyhpp {
 namespace manipulation {
 
 Problem::Problem(const PyWDevicePtr_t& robot)
-    : obj(hpp::manipulation::Problem::create(robot->obj)) {
-    }
+    : obj(hpp::manipulation::Problem::create(robot->obj)) {}
 
-Problem::Problem(const hpp::manipulation::ProblemPtr_t& object) { obj = object; }
+Problem::Problem(const hpp::manipulation::ProblemPtr_t& object) {
+  obj = object;
+}
 
-void Problem::constraintGraph(const PyWGraphPtr_t &graph) {
-    obj->constraintGraph(graph->obj);
+void Problem::constraintGraph(const PyWGraphPtr_t& graph) {
+  obj->constraintGraph(graph->obj);
 }
 
 PyWGraphPtr_t Problem::constraintGraph() const {
-    pyhpp::manipulation::PyWGraph* graph = new PyWGraph(obj->constraintGraph());
-    return std::shared_ptr<PyWGraph>(graph);
+  pyhpp::manipulation::PyWGraph* graph = new PyWGraph(obj->constraintGraph());
+  return std::shared_ptr<PyWGraph>(graph);
 }
 
-void Problem::checkProblem() const {
-    obj->checkProblem();
-}
+void Problem::checkProblem() const { obj->checkProblem(); }
 
 ConfigurationShooterPtr_t Problem::configurationShooter() const {
   return obj->configurationShooter();
@@ -85,7 +84,8 @@ void Problem::addGoalConfig(ConfigurationIn_t config) {
 //     return obj->pathValidationFactory();
 // }
 
-// void Problem::setPathValidationFactory(const core::PathValidationBuilder_t &factory, const value_type &tol) {
+// void Problem::setPathValidationFactory(const core::PathValidationBuilder_t
+// &factory, const value_type &tol) {
 //     obj->setPathValidationFactory(factory, tol);
 // }
 
@@ -97,25 +97,28 @@ void Problem::addGoalConfig(ConfigurationIn_t config) {
 //     return Problem::parameterDescriptions();
 // }
 
-// static const ParameterDescription & parameterDescription(const std::string &name) {
+// static const ParameterDescription & parameterDescription(const std::string
+// &name) {
 //     return Problem::parameterDescription(name);
 // }
 
 void exposeProblem() {
   class_<Problem>("Problem", init<const PyWDevicePtr_t&>())
-  .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(Problem, constraintGraph, PyWGraphPtr_t)
-  .PYHPP_DEFINE_METHOD(Problem, checkProblem)
-  .PYHPP_DEFINE_METHOD(Problem, configurationShooter)
-  .PYHPP_DEFINE_METHOD(Problem, initConfig)
-  .PYHPP_DEFINE_METHOD(Problem, addGoalConfig)
-  // .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(Problem, pathValidation, PathValidationPtr_t)
-  // .PYHPP_DEFINE_METHOD(Problem, manipulationSteeringMethod)
-  // .PYHPP_DEFINE_METHOD(Problem, pathValidationFactory)
-  // .PYHPP_DEFINE_METHOD(Problem, setPathValidationFactory)
-  // .PYHPP_DEFINE_METHOD_STATIC(Problem, declareParameter)
-  // .PYHPP_DEFINE_METHOD_STATIC(Problem, parameterDescriptions)
-  // .PYHPP_DEFINE_METHOD_STATIC(Problem, parameterDescription)
-  ;
+      .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(Problem, constraintGraph,
+                                            PyWGraphPtr_t)
+      .PYHPP_DEFINE_METHOD(Problem, checkProblem)
+      .PYHPP_DEFINE_METHOD(Problem, configurationShooter)
+      .PYHPP_DEFINE_METHOD(Problem, initConfig)
+      .PYHPP_DEFINE_METHOD(Problem, addGoalConfig)
+      // .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(Problem, pathValidation,
+      // PathValidationPtr_t) .PYHPP_DEFINE_METHOD(Problem,
+      // manipulationSteeringMethod) .PYHPP_DEFINE_METHOD(Problem,
+      // pathValidationFactory) .PYHPP_DEFINE_METHOD(Problem,
+      // setPathValidationFactory) .PYHPP_DEFINE_METHOD_STATIC(Problem,
+      // declareParameter) .PYHPP_DEFINE_METHOD_STATIC(Problem,
+      // parameterDescriptions) .PYHPP_DEFINE_METHOD_STATIC(Problem,
+      // parameterDescription)
+      ;
 }
 }  // namespace manipulation
 }  // namespace pyhpp

--- a/src/pyhpp/manipulation/problem.cc
+++ b/src/pyhpp/manipulation/problem.cc
@@ -28,24 +28,85 @@
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/python.hpp>
-#include <hpp/manipulation/problem.hh>
+#include <../src/pyhpp/manipulation/problem.hh>
+#include <../src/pyhpp/manipulation/device.hh>
+#include <../src/pyhpp/manipulation/graph.hh>
+#include <hpp/core/problem.hh>
 
 using namespace boost::python;
 
 namespace pyhpp {
 namespace manipulation {
 
-typedef hpp::manipulation::Problem Problem;
-typedef hpp::manipulation::ProblemPtr_t ProblemPtr_t;
-typedef hpp::manipulation::ProblemConstPtr_t ProblemConstPtr_t;
+Problem::Problem(const PyWDevicePtr_t& robot)
+    : obj(hpp::manipulation::Problem::create(robot->obj)) {
+    }
+
+Problem::Problem(const hpp::manipulation::ProblemPtr_t& object) { obj = object; }
+
+void Problem::constraintGraph(const PyWGraphPtr_t &graph) {
+    obj->constraintGraph(graph->obj);
+}
+
+PyWGraphPtr_t Problem::constraintGraph() const {
+    pyhpp::manipulation::PyWGraph* graph = new PyWGraph(obj->constraintGraph());
+    return std::shared_ptr<PyWGraph>(graph);
+}
+
+void Problem::checkProblem() const {
+    obj->checkProblem();
+}
+
+ConfigurationShooterPtr_t Problem::configurationShooter() const {
+  return obj->configurationShooter();
+}
+
+
+// PathValidationPtr_t Problem::pathValidation() const {
+//     return obj->pathValidation();
+// }
+
+// void Problem::pathValidation(const PathValidationPtr_t &pathValidation) {
+//     obj->pathValidation(pathValidation);
+// }
+
+// SteeringMethodPtr_t Problem::manipulationSteeringMethod() const {
+//     return obj->manipulationSteeringMethod();
+// }
+
+// PathValidationPtr_t Problem::pathValidationFactory() const {
+//     return obj->pathValidationFactory();
+// }
+
+// void Problem::setPathValidationFactory(const core::PathValidationBuilder_t &factory, const value_type &tol) {
+//     obj->setPathValidationFactory(factory, tol);
+// }
+
+// static void declareParameter(const ParameterDescription &desc) {
+//     Problem::declareParameter(desc);
+// }
+
+// static const Container<ParameterDescription> & parameterDescriptions() {
+//     return Problem::parameterDescriptions();
+// }
+
+// static const ParameterDescription & parameterDescription(const std::string &name) {
+//     return Problem::parameterDescription(name);
+// }
 
 void exposeProblem() {
-  register_ptr_to_python<ProblemConstPtr_t>();
-  implicitly_convertible<ProblemPtr_t, ProblemConstPtr_t>();
-  class_<Problem, ProblemPtr_t, boost::noncopyable, bases<hpp::core::Problem> >(
-      "Problem", no_init)
-      .def("create", &Problem::create)
-      .staticmethod("create");
+  class_<Problem>("Problem", init<const PyWDevicePtr_t&>())
+  .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(Problem, constraintGraph, PyWGraphPtr_t)
+  .PYHPP_DEFINE_METHOD(Problem, checkProblem)
+  .PYHPP_DEFINE_METHOD(Problem, configurationShooter)
+  // .PYHPP_DEFINE_GETTER_SETTER_CONST_REF(Problem, pathValidation, PathValidationPtr_t)
+  // .PYHPP_DEFINE_METHOD(Problem, manipulationSteeringMethod)
+  // .PYHPP_DEFINE_METHOD(Problem, pathValidationFactory)
+  // .PYHPP_DEFINE_METHOD(Problem, setPathValidationFactory)
+  // .PYHPP_DEFINE_METHOD_STATIC(Problem, declareParameter)
+  // .PYHPP_DEFINE_METHOD_STATIC(Problem, parameterDescriptions)
+  // .PYHPP_DEFINE_METHOD_STATIC(Problem, parameterDescription)
+  ;
 }
 }  // namespace manipulation
 }  // namespace pyhpp

--- a/src/pyhpp/manipulation/problem.hh
+++ b/src/pyhpp/manipulation/problem.hh
@@ -19,11 +19,11 @@
 #ifndef PYHPP_MANIPULATION_PROBLEM_HH
 #define PYHPP_MANIPULATION_PROBLEM_HH
 
-#include <pyhpp/core/fwd.hh>
-#include <pyhpp/manipulation/fwd.hh>
-#include <hpp/manipulation/problem.hh>
-#include <pyhpp/core/problem.hh>
 #include <hpp/core/configuration-shooter.hh>
+#include <hpp/manipulation/problem.hh>
+#include <pyhpp/core/fwd.hh>
+#include <pyhpp/core/problem.hh>
+#include <pyhpp/manipulation/fwd.hh>
 
 typedef hpp::manipulation::ProblemPtr_t ProblemPtr_t;
 typedef hpp::core::ConfigurationShooterPtr_t ConfigurationShooterPtr_t;
@@ -42,18 +42,19 @@ struct Problem {
   Problem(const PyWDevicePtr_t& robot);
   Problem(const hpp::manipulation::ProblemPtr_t& object);
 
-  void constraintGraph (const PyWGraphPtr_t &graph);
+  void constraintGraph(const PyWGraphPtr_t& graph);
   PyWGraphPtr_t constraintGraph() const;
-  virtual void checkProblem() const; 
+  virtual void checkProblem() const;
   ConfigurationShooterPtr_t configurationShooter() const;
   void initConfig(ConfigurationIn_t inConfig);
   void addGoalConfig(ConfigurationIn_t config);
 
-  // PathValidationPtr_t pathValidation() const; 
-  // void pathValidation (const PathValidationPtr_t &pathValidation); 
+  // PathValidationPtr_t pathValidation() const;
+  // void pathValidation (const PathValidationPtr_t &pathValidation);
   // SteeringMethodPtr_t manipulationSteeringMethod() const;
   // PathValidationPtr_t pathValidationFactory() const;
-  // void 	setPathValidationFactory (const core::PathValidationBuilder_t &factory, const value_type &tol);
+  // void 	setPathValidationFactory (const core::PathValidationBuilder_t
+  // &factory, const value_type &tol);
 };
 
 }  // namespace manipulation

--- a/src/pyhpp/manipulation/problem.hh
+++ b/src/pyhpp/manipulation/problem.hh
@@ -27,6 +27,9 @@
 
 typedef hpp::manipulation::ProblemPtr_t ProblemPtr_t;
 typedef hpp::core::ConfigurationShooterPtr_t ConfigurationShooterPtr_t;
+typedef hpp::constraints::JointAndShape_t JointAndShape_t;
+typedef hpp::constraints::JointAndShapes_t JointAndShapes_t;
+typedef hpp::core::ConfigurationIn_t ConfigurationIn_t;
 
 namespace pyhpp {
 namespace manipulation {
@@ -34,6 +37,7 @@ namespace manipulation {
 // Wrapper class for hpp::manipulation::Problem
 struct Problem {
   ProblemPtr_t obj;
+  hpp::core::Container<JointAndShapes_t> jointAndShapes;
 
   Problem(const PyWDevicePtr_t& robot);
   Problem(const hpp::manipulation::ProblemPtr_t& object);
@@ -42,6 +46,8 @@ struct Problem {
   PyWGraphPtr_t constraintGraph() const;
   virtual void checkProblem() const; 
   ConfigurationShooterPtr_t configurationShooter() const;
+  void initConfig(ConfigurationIn_t inConfig);
+  void addGoalConfig(ConfigurationIn_t config);
 
   // PathValidationPtr_t pathValidation() const; 
   // void pathValidation (const PathValidationPtr_t &pathValidation); 

--- a/src/pyhpp/manipulation/problem.hh
+++ b/src/pyhpp/manipulation/problem.hh
@@ -1,0 +1,56 @@
+// problem.hh
+//
+// Copyright (c) 2025, CNRS
+// Authors: Paul Sardin
+//
+// This file is part of hpp-python
+// hpp-python is free software—you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-python is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-python. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef PYHPP_MANIPULATION_PROBLEM_HH
+#define PYHPP_MANIPULATION_PROBLEM_HH
+
+#include <pyhpp/core/fwd.hh>
+#include <pyhpp/manipulation/fwd.hh>
+#include <hpp/manipulation/problem.hh>
+#include <pyhpp/core/problem.hh>
+#include <hpp/core/configuration-shooter.hh>
+
+typedef hpp::manipulation::ProblemPtr_t ProblemPtr_t;
+typedef hpp::core::ConfigurationShooterPtr_t ConfigurationShooterPtr_t;
+
+namespace pyhpp {
+namespace manipulation {
+
+// Wrapper class for hpp::manipulation::Problem
+struct Problem {
+  ProblemPtr_t obj;
+
+  Problem(const PyWDevicePtr_t& robot);
+  Problem(const hpp::manipulation::ProblemPtr_t& object);
+
+  void constraintGraph (const PyWGraphPtr_t &graph);
+  PyWGraphPtr_t constraintGraph() const;
+  virtual void checkProblem() const; 
+  ConfigurationShooterPtr_t configurationShooter() const;
+
+  // PathValidationPtr_t pathValidation() const; 
+  // void pathValidation (const PathValidationPtr_t &pathValidation); 
+  // SteeringMethodPtr_t manipulationSteeringMethod() const;
+  // PathValidationPtr_t pathValidationFactory() const;
+  // void 	setPathValidationFactory (const core::PathValidationBuilder_t &factory, const value_type &tol);
+};
+
+}  // namespace manipulation
+}  // namespace pyhpp
+
+#endif  // PYHPP_MANIPULATION_PROBLEM_HH

--- a/src/pyhpp/pinocchio/device.cc
+++ b/src/pyhpp/pinocchio/device.cc
@@ -69,6 +69,7 @@ typedef hpp::pinocchio::DevicePtr_t DevicePtr_t;
 typedef hpp::pinocchio::GripperPtr_t GripperPtr_t;
 typedef hpp::pinocchio::Gripper Gripper;
 typedef hpp::pinocchio::Computation_t Computation_t;
+typedef hpp::pinocchio::value_type value_type;
 
 using namespace boost::python;
 
@@ -92,7 +93,11 @@ void exposeGripper() {
   class_<Gripper, GripperPtr_t>("Gripper", no_init)
       .def("create", &Gripper::create)
       .staticmethod("create")
-      .add_property("localPosition", &getObjectPositionInJoint);
+      .add_property("localPosition", &getObjectPositionInJoint)
+      .add_property(
+          "clearance",
+          static_cast<value_type (Gripper::*)() const>(&Gripper::clearance),
+          static_cast<void (Gripper::*)(const value_type&)>(&Gripper::clearance));
   class_<std::map<std::string, GripperPtr_t> >("GripperMap")
       .def(
           boost::python::map_indexing_suite<std::map<std::string, GripperPtr_t>,

--- a/src/pyhpp/pinocchio/device.cc
+++ b/src/pyhpp/pinocchio/device.cc
@@ -97,7 +97,8 @@ void exposeGripper() {
       .add_property(
           "clearance",
           static_cast<value_type (Gripper::*)() const>(&Gripper::clearance),
-          static_cast<void (Gripper::*)(const value_type&)>(&Gripper::clearance));
+          static_cast<void (Gripper::*)(const value_type&)>(
+              &Gripper::clearance));
   class_<std::map<std::string, GripperPtr_t> >("GripperMap")
       .def(
           boost::python::map_indexing_suite<std::map<std::string, GripperPtr_t>,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,9 @@ set(PYTHON_UNIT_TESTS
     path-planner
     rrt
     path
-    constraint_graph)
+    constraint_graph
+    graph_factory
+    graph_factory2)
 
 foreach(UNIT_TEST ${PYTHON_UNIT_TESTS})
   add_python_unit_test(${UNIT_TEST} tests/${UNIT_TEST}.py)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,8 @@ set(PYTHON_UNIT_TESTS
     differentiable-function
     path-planner
     rrt
-    path)
+    path
+    constraint_graph)
 
 foreach(UNIT_TEST ${PYTHON_UNIT_TESTS})
   add_python_unit_test(${UNIT_TEST} tests/${UNIT_TEST}.py)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,6 @@ set(PYTHON_UNIT_TESTS
     rrt
     path
     constraint_graph
-    graph_factory
     graph_factory2)
 
 foreach(UNIT_TEST ${PYTHON_UNIT_TESTS})

--- a/tests/constraint_graph.py
+++ b/tests/constraint_graph.py
@@ -1,5 +1,4 @@
 from pyhpp.manipulation import Device, urdf, Graph, Problem
-from pyhpp.core import ConfigurationShooter
 import numpy as np
 from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
 

--- a/tests/constraint_graph.py
+++ b/tests/constraint_graph.py
@@ -1,0 +1,145 @@
+
+from pyhpp.manipulation import Device, Graph, Problem
+
+import numpy as np
+from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
+
+    
+from pyhpp.gepetto import Viewer
+from pyhpp.core import ConfigurationShooter
+
+from pyhpp.constraints import (
+    RelativeTransformation,
+    Transformation,
+    ComparisonTypes,
+    ComparisonType,
+    BySubstitution,
+    Implicit,
+)
+
+urdfFilename = "package://example-robot-data/robots/ur_description/urdf/ur5_gripper.urdf"
+srdfFilename = "package://example-robot-data/robots/ur_description/srdf/ur5_gripper.srdf"
+
+urdfFilenameBall = "package://hpp_environments/urdf/ur_benchmark/pokeball.urdf"
+srdfFilenameBall = "package://hpp_environments/srdf/ur_benchmark/pokeball.srdf"
+
+r0_pose = SE3(rotation = np.identity(3), translation = np.array([-0.25, 0, 0]))
+r1_pose = SE3(rotation = np.identity(3), translation = np.array([1, 0, 0]))
+
+robot = Device("bot")
+viewer = Viewer("tutorial_1", robot.asPinDevice())
+viewer.addURDFToScene(0, "ur5", "anchor", urdfFilename, srdfFilename, r0_pose)
+viewer.addURDFToScene(0, "pokeball", "freeflyer", urdfFilenameBall, srdfFilenameBall, r1_pose)
+
+#urdf.loadModel(robot, 0, "ur5", "anchor", urdfFilename, srdfFilename, r0_pose)
+#urdf.loadModel(robot, 0, "pokeball", "freeflyer", urdfFilenameBall, srdfFilenameBall, r1_pose)
+
+model = robot.model()
+lowerLimit = model.lowerPositionLimit
+upperLimit = model.upperPositionLimit
+
+pokeball_bounds = [
+    [-0.4, 0.4],
+    [-0.4, 0.4],
+    [-0.1, 2.0],
+    [-1.0001, 1.0001],
+    [-1.0001, 1.0001],
+    [-1.0001, 1.0001],
+    [-1.0001, 1.0001],
+]
+
+ij = model.getJointId("pokeball/root_joint")
+iq = model.idx_qs[ij]
+
+for i, (lower, upper) in enumerate(pokeball_bounds):
+    lowerLimit[iq + i] = lower
+    upperLimit[iq + i] = upper
+
+
+problem = Problem(robot)
+
+graph = Graph("graph", robot, problem)
+
+#Create states
+state_placement = graph.createState("placement", False, 0)
+state_grasp_placement = graph.createState("grasp-placement", False, 0)
+state_gripper_above_ball = graph.createState("gripper-above-ball", False, 0)
+state_ball_above_ground = graph.createState("ball-above-ground", False, 0)
+state_grasp = graph.createState("grasp", False, 0)
+
+#Create transitions
+transitions_transit = graph.createTransition(state_placement, state_placement, "transit", 1, state_placement)
+
+transitions_approach_ball = graph.createTransition(state_placement, state_gripper_above_ball, "approach-ball", 1, state_placement)
+transitions_move_gripper_away = graph.createTransition(state_gripper_above_ball, state_placement, "move-gripper-away", 1, state_placement)
+transitions_grasp_ball = graph.createTransition(state_gripper_above_ball, state_grasp_placement, "grasp-ball", 1, state_placement)
+transitions_move_gripper_up = graph.createTransition(state_grasp_placement, state_gripper_above_ball, "move-gripper-up", 1, state_placement)
+transitions_take_ball_up = graph.createTransition(state_grasp_placement, state_ball_above_ground, "take-ball-up", 1, state_grasp)
+transitions_put_ball_down = graph.createTransition(state_ball_above_ground, state_grasp_placement, "put-ball-down", 1, state_grasp)
+transitions_take_ball_away = graph.createTransition(state_ball_above_ground, state_grasp, "take-ball-away", 1, state_grasp)
+transitions_approach_ground = graph.createTransition(state_grasp, state_ball_above_ground, "approach-ground", 1, state_grasp)
+transitions_transfer = graph.createTransition(state_grasp, state_grasp, "transfer", 1, state_grasp)
+
+joint2 = robot.model().getJointId("pokeball/root_joint")
+joint1 = robot.model().getJointId("ur5/wrist_3_joint")
+Id = SE3.Identity() 
+
+m =  [
+        False,
+        False,
+        True,
+        True,
+        True,
+        False,
+    ]
+q = Quaternion(0, 0, 0, 1) 
+ballGround = SE3(q, np.array([0, 0, 0.15]))
+pc = Transformation.create("placementConstraint", robot.asPinDevice(), joint2, ballGround, Id, m)
+cts = ComparisonTypes()
+cts[:] = (
+    ComparisonType.EqualToZero,
+    ComparisonType.EqualToZero,
+    ComparisonType.EqualToZero,
+    
+)
+implicit_mask = [True, True, True]
+implicitPlacementConstraint = Implicit.create(pc, cts, implicit_mask)
+
+
+q = Quaternion(0.5, 0.5, -0.5, 0.5) 
+ballInGripper = SE3(q, np.array([0, 0.137, 0]))
+m = Mask()
+m[:] = (True,) * 6
+pc = RelativeTransformation.create("grasp", robot.asPinDevice(), joint1, joint2, ballInGripper, Id, m)
+cts = ComparisonTypes()
+cts[:] = (
+    ComparisonType.EqualToZero,
+    ComparisonType.EqualToZero,
+    ComparisonType.EqualToZero,
+    ComparisonType.EqualToZero,
+    ComparisonType.EqualToZero,
+    ComparisonType.EqualToZero,
+)
+implicitGraspConstraint = Implicit.create(pc, cts, m)
+
+
+# Set constraints of nodes and edges
+graph.addNumericalConstraint(state_placement, implicitPlacementConstraint)
+graph.addNumericalConstraint(state_grasp, implicitGraspConstraint)
+
+graph.maxIterations(100)
+graph.errorThreshold(0.00001)
+
+graph.initialize()
+
+configurationShooter = problem.configurationShooter()
+solver = BySubstitution(robot.configSpace())
+
+for i in range(100):
+    q = configurationShooter.shoot()
+    res = graph.applyStateConstraints (state_grasp, q)
+    if res.success: break
+if (res.success):
+    viewer.applyConfiguration(res.configuration)
+    print("after applying constraints: ",res.configuration)
+

--- a/tests/constraint_graph.py
+++ b/tests/constraint_graph.py
@@ -1,4 +1,5 @@
 from pyhpp.manipulation import Device, urdf, Graph, Problem
+from pyhpp.core import ConfigurationShooter # noqa: F401
 import numpy as np
 from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
 

--- a/tests/constraint_graph.py
+++ b/tests/constraint_graph.py
@@ -1,5 +1,5 @@
 from pyhpp.manipulation import Device, urdf, Graph, Problem
-
+from pyhpp.core import ConfigurationShooter
 import numpy as np
 from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
 

--- a/tests/constraint_graph.py
+++ b/tests/constraint_graph.py
@@ -1,10 +1,8 @@
-
 from pyhpp.manipulation import Device, urdf, Graph, Problem
 
 import numpy as np
 from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
 
-from pyhpp.core import ConfigurationShooter
 
 from pyhpp.constraints import (
     RelativeTransformation,
@@ -15,19 +13,25 @@ from pyhpp.constraints import (
     Implicit,
 )
 
-urdfFilename = "package://example-robot-data/robots/ur_description/urdf/ur5_gripper.urdf"
-srdfFilename = "package://example-robot-data/robots/ur_description/srdf/ur5_gripper.srdf"
+urdfFilename = (
+    "package://example-robot-data/robots/ur_description/urdf/ur5_gripper.urdf"
+)
+srdfFilename = (
+    "package://example-robot-data/robots/ur_description/srdf/ur5_gripper.srdf"
+)
 
 urdfFilenameBall = "package://hpp_environments/urdf/ur_benchmark/pokeball.urdf"
 srdfFilenameBall = "package://hpp_environments/srdf/ur_benchmark/pokeball.srdf"
 
-r0_pose = SE3(rotation = np.identity(3), translation = np.array([-0.25, 0, 0]))
-r1_pose = SE3(rotation = np.identity(3), translation = np.array([1, 0, 0]))
+r0_pose = SE3(rotation=np.identity(3), translation=np.array([-0.25, 0, 0]))
+r1_pose = SE3(rotation=np.identity(3), translation=np.array([1, 0, 0]))
 
 robot = Device("bot")
 
 urdf.loadModel(robot, 0, "ur5", "anchor", urdfFilename, srdfFilename, r0_pose)
-urdf.loadModel(robot, 0, "pokeball", "freeflyer", urdfFilenameBall, srdfFilenameBall, r1_pose)
+urdf.loadModel(
+    robot, 0, "pokeball", "freeflyer", urdfFilenameBall, srdfFilenameBall, r1_pose
+)
 
 
 robot.setJointBounds(
@@ -54,57 +58,84 @@ problem = Problem(robot)
 
 graph = Graph("graph", robot, problem)
 
-#Create states
+# Create states
 state_placement = graph.createState("placement", False, 0)
 state_grasp_placement = graph.createState("grasp-placement", False, 0)
 state_gripper_above_ball = graph.createState("gripper-above-ball", False, 0)
 state_ball_above_ground = graph.createState("ball-above-ground", False, 0)
 state_grasp = graph.createState("grasp", False, 0)
 
-#Create transitions
-transitions_transit = graph.createTransition(state_placement, state_placement, "transit", 1, state_placement)
+# Create transitions
+transitions_transit = graph.createTransition(
+    state_placement, state_placement, "transit", 1, state_placement
+)
 
-transitions_approach_ball = graph.createTransition(state_placement, state_gripper_above_ball, "approach-ball", 1, state_placement)
-transitions_move_gripper_away = graph.createTransition(state_gripper_above_ball, state_placement, "move-gripper-away", 1, state_placement)
-transitions_grasp_ball = graph.createTransition(state_gripper_above_ball, state_grasp_placement, "grasp-ball", 1, state_placement)
-transitions_move_gripper_up = graph.createTransition(state_grasp_placement, state_gripper_above_ball, "move-gripper-up", 1, state_placement)
-transitions_take_ball_up = graph.createTransition(state_grasp_placement, state_ball_above_ground, "take-ball-up", 1, state_grasp)
-transitions_put_ball_down = graph.createTransition(state_ball_above_ground, state_grasp_placement, "put-ball-down", 1, state_grasp)
-transitions_take_ball_away = graph.createTransition(state_ball_above_ground, state_grasp, "take-ball-away", 1, state_grasp)
-transitions_approach_ground = graph.createTransition(state_grasp, state_ball_above_ground, "approach-ground", 1, state_grasp)
-transitions_transfer = graph.createTransition(state_grasp, state_grasp, "transfer", 1, state_grasp)
+transitions_approach_ball = graph.createTransition(
+    state_placement, state_gripper_above_ball, "approach-ball", 1, state_placement
+)
+transitions_move_gripper_away = graph.createTransition(
+    state_gripper_above_ball, state_placement, "move-gripper-away", 1, state_placement
+)
+transitions_grasp_ball = graph.createTransition(
+    state_gripper_above_ball, state_grasp_placement, "grasp-ball", 1, state_placement
+)
+transitions_move_gripper_up = graph.createTransition(
+    state_grasp_placement,
+    state_gripper_above_ball,
+    "move-gripper-up",
+    1,
+    state_placement,
+)
+transitions_take_ball_up = graph.createTransition(
+    state_grasp_placement, state_ball_above_ground, "take-ball-up", 1, state_grasp
+)
+transitions_put_ball_down = graph.createTransition(
+    state_ball_above_ground, state_grasp_placement, "put-ball-down", 1, state_grasp
+)
+transitions_take_ball_away = graph.createTransition(
+    state_ball_above_ground, state_grasp, "take-ball-away", 1, state_grasp
+)
+transitions_approach_ground = graph.createTransition(
+    state_grasp, state_ball_above_ground, "approach-ground", 1, state_grasp
+)
+transitions_transfer = graph.createTransition(
+    state_grasp, state_grasp, "transfer", 1, state_grasp
+)
 
 joint2 = robot.model().getJointId("pokeball/root_joint")
 joint1 = robot.model().getJointId("ur5/wrist_3_joint")
-Id = SE3.Identity() 
+Id = SE3.Identity()
 
-m =  [
-        False,
-        False,
-        True,
-        True,
-        True,
-        False,
-    ]
-q = Quaternion(0, 0, 0, 1) 
+m = [
+    False,
+    False,
+    True,
+    True,
+    True,
+    False,
+]
+q = Quaternion(0, 0, 0, 1)
 ballGround = SE3(q, np.array([0, 0, 0.15]))
-pc = Transformation.create("placementConstraint", robot.asPinDevice(), joint2, ballGround, Id, m)
+pc = Transformation.create(
+    "placementConstraint", robot.asPinDevice(), joint2, ballGround, Id, m
+)
 cts = ComparisonTypes()
 cts[:] = (
     ComparisonType.EqualToZero,
     ComparisonType.EqualToZero,
     ComparisonType.EqualToZero,
-    
 )
 implicit_mask = [True, True, True]
 implicitPlacementConstraint = Implicit.create(pc, cts, implicit_mask)
 
 
-q = Quaternion(0.5, 0.5, -0.5, 0.5) 
+q = Quaternion(0.5, 0.5, -0.5, 0.5)
 ballInGripper = SE3(q, np.array([0, 0.137, 0]))
 m = Mask()
 m[:] = (True,) * 6
-pc = RelativeTransformation.create("grasp", robot.asPinDevice(), joint1, joint2, ballInGripper, Id, m)
+pc = RelativeTransformation.create(
+    "grasp", robot.asPinDevice(), joint1, joint2, ballInGripper, Id, m
+)
 cts = ComparisonTypes()
 cts[:] = (
     ComparisonType.EqualToZero,
@@ -131,8 +162,8 @@ solver = BySubstitution(robot.configSpace())
 
 for i in range(100):
     q = configurationShooter.shoot()
-    res = graph.applyStateConstraints (state_grasp, q)
-    if res.success: break
-if (res.success):
-    print("after applying constraints: ",res.configuration)
-
+    res = graph.applyStateConstraints(state_grasp, q)
+    if res.success:
+        break
+if res.success:
+    print("after applying constraints: ", res.configuration)

--- a/tests/constraint_graph.py
+++ b/tests/constraint_graph.py
@@ -29,27 +29,26 @@ robot = Device("bot")
 urdf.loadModel(robot, 0, "ur5", "anchor", urdfFilename, srdfFilename, r0_pose)
 urdf.loadModel(robot, 0, "pokeball", "freeflyer", urdfFilenameBall, srdfFilenameBall, r1_pose)
 
-model = robot.model()
-lowerLimit = model.lowerPositionLimit
-upperLimit = model.upperPositionLimit
 
-pokeball_bounds = [
-    [-0.4, 0.4],
-    [-0.4, 0.4],
-    [-0.1, 2.0],
-    [-1.0001, 1.0001],
-    [-1.0001, 1.0001],
-    [-1.0001, 1.0001],
-    [-1.0001, 1.0001],
-]
-
-ij = model.getJointId("pokeball/root_joint")
-iq = model.idx_qs[ij]
-
-for i, (lower, upper) in enumerate(pokeball_bounds):
-    lowerLimit[iq + i] = lower
-    upperLimit[iq + i] = upper
-
+robot.setJointBounds(
+    "pokeball/root_joint",
+    [
+        -0.4,
+        0.4,
+        -0.4,
+        0.4,
+        -0.1,
+        1.0,
+        -1.0001,
+        1.0001,
+        -1.0001,
+        1.0001,
+        -1.0001,
+        1.0001,
+        -1.0001,
+        1.0001,
+    ],
+)
 
 problem = Problem(robot)
 

--- a/tests/constraint_graph.py
+++ b/tests/constraint_graph.py
@@ -1,11 +1,9 @@
 
-from pyhpp.manipulation import Device, Graph, Problem
+from pyhpp.manipulation import Device, urdf, Graph, Problem
 
 import numpy as np
 from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
 
-    
-from pyhpp.gepetto import Viewer
 from pyhpp.core import ConfigurationShooter
 
 from pyhpp.constraints import (
@@ -27,12 +25,9 @@ r0_pose = SE3(rotation = np.identity(3), translation = np.array([-0.25, 0, 0]))
 r1_pose = SE3(rotation = np.identity(3), translation = np.array([1, 0, 0]))
 
 robot = Device("bot")
-viewer = Viewer("tutorial_1", robot.asPinDevice())
-viewer.addURDFToScene(0, "ur5", "anchor", urdfFilename, srdfFilename, r0_pose)
-viewer.addURDFToScene(0, "pokeball", "freeflyer", urdfFilenameBall, srdfFilenameBall, r1_pose)
 
-#urdf.loadModel(robot, 0, "ur5", "anchor", urdfFilename, srdfFilename, r0_pose)
-#urdf.loadModel(robot, 0, "pokeball", "freeflyer", urdfFilenameBall, srdfFilenameBall, r1_pose)
+urdf.loadModel(robot, 0, "ur5", "anchor", urdfFilename, srdfFilename, r0_pose)
+urdf.loadModel(robot, 0, "pokeball", "freeflyer", urdfFilenameBall, srdfFilenameBall, r1_pose)
 
 model = robot.model()
 lowerLimit = model.lowerPositionLimit
@@ -140,6 +135,5 @@ for i in range(100):
     res = graph.applyStateConstraints (state_grasp, q)
     if res.success: break
 if (res.success):
-    viewer.applyConfiguration(res.configuration)
     print("after applying constraints: ",res.configuration)
 

--- a/tests/constraint_graph.py
+++ b/tests/constraint_graph.py
@@ -1,5 +1,5 @@
 from pyhpp.manipulation import Device, urdf, Graph, Problem
-from pyhpp.core import ConfigurationShooter # noqa: F401
+from pyhpp.core import ConfigurationShooter  # noqa: F401
 import numpy as np
 from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
 

--- a/tests/constraint_graph.py
+++ b/tests/constraint_graph.py
@@ -1,4 +1,5 @@
 from pyhpp.manipulation import Device, urdf, Graph, Problem
+from pyhpp.core import ConfigurationShooter
 import numpy as np
 from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
 

--- a/tests/construction_set.py
+++ b/tests/construction_set.py
@@ -1,93 +1,50 @@
 from math import pi
 import numpy as np
 from pinocchio import SE3
-from pyhpp.pinocchio import Device
-from pyhpp.gepetto import Viewer
-
-robot = Device.create("construction_set")
-
-# Create viewer
-viewer = Viewer("construction_set", robot)
+from pyhpp.manipulation import Device, urdf
 
 # Load two UR3 robots
-urdfFilename = (
-    "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
-)
-srdfFilename = (
-    "package://example-robot-data/robots/ur_description/srdf/ur3_gripper.srdf"
-)
+urdfFilename = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
+srdfFilename = "package://example-robot-data/robots/ur_description/srdf/ur3_gripper.srdf"
 
-r0_pose = SE3(rotation=np.identity(3), translation=np.array([-0.25, 0, 0]))
-r1_pose = SE3(
-    rotation=np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 1]]),
-    translation=np.array([0.25, 0, 0]),
-)
-
-# urdf.loadModel(robot, 0, "r0", "anchor", urdfFilename, srdfFilename, r0_pose)
-# urdf.loadModel(robot, 0, "r1", "anchor", urdfFilename, srdfFilename, r1_pose)
-viewer.addURDFToScene(0, "r0", "anchor", urdfFilename, srdfFilename, r0_pose)
-viewer.addURDFToScene(0, "r1", "anchor", urdfFilename, srdfFilename, r1_pose)
+r0_pose = SE3(rotation = np.identity(3), translation = np.array([-0.25, 0, 0]))
+r1_pose = SE3(rotation = np.identity(3), translation = np.array([ 0.25, 0, 0]))
+robot = Device("construction-set")
+urdf.loadModel(robot, 0, "r0", "anchor", urdfFilename, srdfFilename, r0_pose)
+urdf.loadModel(robot, 0, "r1", "anchor", urdfFilename, srdfFilename, r1_pose)
 
 # Load environment
 urdfFilename = "package://hpp_environments/urdf/construction_set/ground.urdf"
 srdfFilename = "package://hpp_environments/srdf/construction_set/ground.srdf"
-# urdf.loadModel(robot, 0, "ground", "anchor", urdfFilename, srdfFilename, SE3.Identity())
-viewer.addURDFToScene(0, "ground", "anchor", urdfFilename, srdfFilename, SE3.Identity())
-
-q = np.array(
-    [
-        pi / 6,
-        -pi / 2,
-        pi / 2,
-        0,
-        0,
-        0,
-    ]
-    + [
-        pi / 6,
-        -pi / 2,
-        pi / 2,
-        0,
-        0,
-        0,
-    ]
-)
-viewer.applyConfiguration(q)
+urdf.loadModel(robot, 0, "ground", "anchor", urdfFilename, srdfFilename, SE3.Identity())
 
 # Load spheres
 nSphere = 2
 nCylinder = 2
 
-objects = list()
+objects = list ()
 urdfFilename = "package://hpp_environments/urdf/construction_set/sphere.urdf"
 srdfFilename = "package://hpp_environments/srdf/construction_set/sphere.srdf"
-for i in range(nSphere):
-    # urdf.loadModel(robot, 0, f"sphere{i}", "freeflyer", urdfFilename, srdfFilename, SE3.Identity())
-    viewer.addURDFToScene(
-        0, f"sphere{i}", "freeflyer", urdfFilename, srdfFilename, SE3.Identity()
-    )
-    objects.append(f"sphere{i}")
+for i in range (nSphere):
+    urdf.loadModel(robot, 0, f"sphere{i}", "freeflyer", urdfFilename, srdfFilename, SE3.Identity())
+    objects.append (f"sphere{i}")
 
 # Load cylinders
 urdfFilename = "package://hpp_environments/urdf/construction_set/cylinder_08.urdf"
 srdfFilename = "package://hpp_environments/srdf/construction_set/cylinder_08.srdf"
-for i in range(nCylinder):
-    # urdf.loadModel(robot, 0, f"cylinder{i}", "freeflyer", urdfFilename, srdfFilename,SE3.Identity())
-    viewer.addURDFToScene(
-        0, f"cylinder{i}", "freeflyer", urdfFilename, srdfFilename, SE3.Identity()
-    )
-    objects.append(f"cylinder{i}")
+for i in range (nCylinder):
+    urdf.loadModel(robot, 0, f"cylinder{i}", "freeflyer", urdfFilename, srdfFilename,
+                   SE3.Identity())
+    objects.append (f"cylinder{i}")
 
 # Set joint bounds
 # Set robot joint bounds
-jointBounds = {
-    "r0/shoulder_pan_joint": [-pi, 4],
-    "r1/shoulder_pan_joint": [-pi, 4],
-    "r0/shoulder_lift_joint": [-pi, 0],
-    "r1/shoulder_lift_joint": [-pi, 0],
-    "r0/elbow_joint": [-2.6, 2.6],
-    "r1/elbow_joint": [-2.6, 2.6],
-}
+jointBounds =  {'r0/shoulder_pan_joint': [-pi, 4],
+                'r1/shoulder_pan_joint': [-pi, 4],
+                'r0/shoulder_lift_joint': [-pi, 0],
+                'r1/shoulder_lift_joint': [-pi, 0],
+                'r0/elbow_joint': [-2.6, 2.6],
+                'r1/elbow_joint': [-2.6, 2.6]}
 m = robot.model()
 lowerLimit = m.lowerPositionLimit
 upperLimit = m.upperPositionLimit
@@ -95,19 +52,23 @@ for jn, [lower, upper] in jointBounds.items():
     lowerLimit[m.getJointId(jn)] = lower
     upperLimit[m.getJointId(jn)] = upper
 
-for i in range(nSphere):
+for i in range (nSphere):
     ij = m.getJointId(f"sphere{i}/root_joint")
     iq = m.idx_qs[ij]
     nq = m.nqs[ij]
-    lowerLimit[iq : iq + nq] = [-1.0, -1.0, -0.1, -1.0001, -1.0001, -1.0001, -1.0001]
-    upperLimit[iq : iq + nq] = [1.0, 1.0, 0.1, 1.0001, 1.0001, 1.0001, 1.0001]
+    lowerLimit[iq:iq+nq] = \
+               [-1., -1., -.1, -1.0001, -1.0001, -1.0001, -1.0001]
+    upperLimit[iq:iq+nq] = \
+               [ 1.,  1.,  .1,  1.0001,  1.0001,  1.0001,  1.0001]
 
-for i in range(nCylinder):
+for i in range (nCylinder):
     ij = m.getJointId(f"cylinder{i}/root_joint")
     iq = m.idx_qs[ij]
     nq = m.nqs[ij]
-    lowerLimit[iq : iq + nq] = [-1.0, -1.0, -0.1, -1.0001, -1.0001, -1.0001, -1.0001]
-    upperLimit[iq : iq + nq] = [1.0, 1.0, 0.1, 1.0001, 1.0001, 1.0001, 1.0001]
+    lowerLimit[iq:iq+nq] = \
+               [-1., -1., -.1, -1.0001, -1.0001, -1.0001, -1.0001]
+    upperLimit[iq:iq+nq] = \
+               [ 1.,  1.,  .1,  1.0001,  1.0001,  1.0001,  1.0001]
 
 m.lowerPositionLimit = lowerLimit
 m.upperPositionLimit = upperLimit

--- a/tests/construction_set.py
+++ b/tests/construction_set.py
@@ -4,11 +4,15 @@ from pinocchio import SE3
 from pyhpp.manipulation import Device, urdf
 
 # Load two UR3 robots
-urdfFilename = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
-srdfFilename = "package://example-robot-data/robots/ur_description/srdf/ur3_gripper.srdf"
+urdfFilename = (
+    "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
+)
+srdfFilename = (
+    "package://example-robot-data/robots/ur_description/srdf/ur3_gripper.srdf"
+)
 
-r0_pose = SE3(rotation = np.identity(3), translation = np.array([-0.25, 0, 0]))
-r1_pose = SE3(rotation = np.identity(3), translation = np.array([ 0.25, 0, 0]))
+r0_pose = SE3(rotation=np.identity(3), translation=np.array([-0.25, 0, 0]))
+r1_pose = SE3(rotation=np.identity(3), translation=np.array([0.25, 0, 0]))
 robot = Device("construction-set")
 urdf.loadModel(robot, 0, "r0", "anchor", urdfFilename, srdfFilename, r0_pose)
 urdf.loadModel(robot, 0, "r1", "anchor", urdfFilename, srdfFilename, r1_pose)
@@ -22,29 +26,40 @@ urdf.loadModel(robot, 0, "ground", "anchor", urdfFilename, srdfFilename, SE3.Ide
 nSphere = 2
 nCylinder = 2
 
-objects = list ()
+objects = list()
 urdfFilename = "package://hpp_environments/urdf/construction_set/sphere.urdf"
 srdfFilename = "package://hpp_environments/srdf/construction_set/sphere.srdf"
-for i in range (nSphere):
-    urdf.loadModel(robot, 0, f"sphere{i}", "freeflyer", urdfFilename, srdfFilename, SE3.Identity())
-    objects.append (f"sphere{i}")
+for i in range(nSphere):
+    urdf.loadModel(
+        robot, 0, f"sphere{i}", "freeflyer", urdfFilename, srdfFilename, SE3.Identity()
+    )
+    objects.append(f"sphere{i}")
 
 # Load cylinders
 urdfFilename = "package://hpp_environments/urdf/construction_set/cylinder_08.urdf"
 srdfFilename = "package://hpp_environments/srdf/construction_set/cylinder_08.srdf"
-for i in range (nCylinder):
-    urdf.loadModel(robot, 0, f"cylinder{i}", "freeflyer", urdfFilename, srdfFilename,
-                   SE3.Identity())
-    objects.append (f"cylinder{i}")
+for i in range(nCylinder):
+    urdf.loadModel(
+        robot,
+        0,
+        f"cylinder{i}",
+        "freeflyer",
+        urdfFilename,
+        srdfFilename,
+        SE3.Identity(),
+    )
+    objects.append(f"cylinder{i}")
 
 # Set joint bounds
 # Set robot joint bounds
-jointBounds =  {'r0/shoulder_pan_joint': [-pi, 4],
-                'r1/shoulder_pan_joint': [-pi, 4],
-                'r0/shoulder_lift_joint': [-pi, 0],
-                'r1/shoulder_lift_joint': [-pi, 0],
-                'r0/elbow_joint': [-2.6, 2.6],
-                'r1/elbow_joint': [-2.6, 2.6]}
+jointBounds = {
+    "r0/shoulder_pan_joint": [-pi, 4],
+    "r1/shoulder_pan_joint": [-pi, 4],
+    "r0/shoulder_lift_joint": [-pi, 0],
+    "r1/shoulder_lift_joint": [-pi, 0],
+    "r0/elbow_joint": [-2.6, 2.6],
+    "r1/elbow_joint": [-2.6, 2.6],
+}
 m = robot.model()
 lowerLimit = m.lowerPositionLimit
 upperLimit = m.upperPositionLimit
@@ -52,23 +67,19 @@ for jn, [lower, upper] in jointBounds.items():
     lowerLimit[m.getJointId(jn)] = lower
     upperLimit[m.getJointId(jn)] = upper
 
-for i in range (nSphere):
+for i in range(nSphere):
     ij = m.getJointId(f"sphere{i}/root_joint")
     iq = m.idx_qs[ij]
     nq = m.nqs[ij]
-    lowerLimit[iq:iq+nq] = \
-               [-1., -1., -.1, -1.0001, -1.0001, -1.0001, -1.0001]
-    upperLimit[iq:iq+nq] = \
-               [ 1.,  1.,  .1,  1.0001,  1.0001,  1.0001,  1.0001]
+    lowerLimit[iq : iq + nq] = [-1.0, -1.0, -0.1, -1.0001, -1.0001, -1.0001, -1.0001]
+    upperLimit[iq : iq + nq] = [1.0, 1.0, 0.1, 1.0001, 1.0001, 1.0001, 1.0001]
 
-for i in range (nCylinder):
+for i in range(nCylinder):
     ij = m.getJointId(f"cylinder{i}/root_joint")
     iq = m.idx_qs[ij]
     nq = m.nqs[ij]
-    lowerLimit[iq:iq+nq] = \
-               [-1., -1., -.1, -1.0001, -1.0001, -1.0001, -1.0001]
-    upperLimit[iq:iq+nq] = \
-               [ 1.,  1.,  .1,  1.0001,  1.0001,  1.0001,  1.0001]
+    lowerLimit[iq : iq + nq] = [-1.0, -1.0, -0.1, -1.0001, -1.0001, -1.0001, -1.0001]
+    upperLimit[iq : iq + nq] = [1.0, 1.0, 0.1, 1.0001, 1.0001, 1.0001, 1.0001]
 
 m.lowerPositionLimit = lowerLimit
 m.upperPositionLimit = upperLimit

--- a/tests/graph_factory.py
+++ b/tests/graph_factory.py
@@ -1,15 +1,16 @@
-
 from math import sqrt
 import numpy as np
 
 from pyhpp.manipulation.constraint_graph_factory import Rule, ConstraintGraphFactory
 from pyhpp.manipulation import Device, urdf, Graph, Problem
-from pyhpp.constraints import Implicit, LockedJoint
-from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
+from pyhpp.constraints import LockedJoint
+from pinocchio import SE3
 
 # Robot and environment file paths
 pr2_urdf = "package://example-robot-data/robots/pr2_description/urdf/pr2.urdf"
-pr2_srdf = "package://example-robot-data/robots/pr2_description/srdf/pr2_manipulation.srdf"
+pr2_srdf = (
+    "package://example-robot-data/robots/pr2_description/srdf/pr2_manipulation.srdf"
+)
 box_urdf = "package://hpp_tutorial/urdf/box.urdf"
 box_srdf = "package://hpp_tutorial/srdf/box.srdf"
 kitchen_urdf = "package://hpp_tutorial/urdf/kitchen_area.urdf"
@@ -27,7 +28,9 @@ urdf.loadModel(robot, 0, "box", "freeflyer", box_urdf, box_srdf, box_pose)
 
 # Load kitchen environment
 kitchen_pose = SE3(rotation=np.identity(3), translation=np.array([0, 0, 0]))
-urdf.loadModel(robot, 0, "kitchen_area", "anchor", kitchen_urdf, kitchen_srdf, kitchen_pose)
+urdf.loadModel(
+    robot, 0, "kitchen_area", "anchor", kitchen_urdf, kitchen_srdf, kitchen_pose
+)
 
 model = robot.model()
 
@@ -65,8 +68,12 @@ rank = rankInConfiguration["box/root_joint"]
 q_goal[rank : rank + 3] = [-2.5, -4.5, 0.746]
 
 # Create constraints
-ll = LockedJoint.create(robot.asPinDevice(), "pr2/l_gripper_l_finger_joint", np.array([0.5]))
-lr = LockedJoint.create(robot.asPinDevice(), "pr2/l_gripper_r_finger_joint", np.array([0.5]))
+ll = LockedJoint.create(
+    robot.asPinDevice(), "pr2/l_gripper_l_finger_joint", np.array([0.5])
+)
+lr = LockedJoint.create(
+    robot.asPinDevice(), "pr2/l_gripper_r_finger_joint", np.array([0.5])
+)
 
 # Create the constraint graph
 grippers = ["pr2/l_gripper"]
@@ -95,5 +102,3 @@ problem.initConfig(q_init)
 problem.addGoalConfig(q_goal)
 
 print("Script completed!")
-
-

--- a/tests/graph_factory.py
+++ b/tests/graph_factory.py
@@ -1,0 +1,99 @@
+
+from math import sqrt
+import numpy as np
+
+from pyhpp.manipulation.constraint_graph_factory import Rule, ConstraintGraphFactory
+from pyhpp.manipulation import Device, urdf, Graph, Problem
+from pyhpp.constraints import Implicit, LockedJoint
+from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
+
+# Robot and environment file paths
+pr2_urdf = "package://example-robot-data/robots/pr2_description/urdf/pr2.urdf"
+pr2_srdf = "package://example-robot-data/robots/pr2_description/srdf/pr2_manipulation.srdf"
+box_urdf = "package://hpp_tutorial/urdf/box.urdf"
+box_srdf = "package://hpp_tutorial/srdf/box.srdf"
+kitchen_urdf = "package://hpp_tutorial/urdf/kitchen_area.urdf"
+kitchen_srdf = "package://hpp_tutorial/srdf/kitchen_area.srdf"
+
+robot = Device("pr2-box")
+
+# Load PR2 robot
+pr2_pose = SE3(rotation=np.identity(3), translation=np.array([0, 0, 0]))
+urdf.loadModel(robot, 0, "pr2", "freeflyer", pr2_urdf, pr2_srdf, pr2_pose)
+
+# Load box to be manipulated
+box_pose = SE3(rotation=np.identity(3), translation=np.array([-2.5, -4, 0.746]))
+urdf.loadModel(robot, 0, "box", "freeflyer", box_urdf, box_srdf, box_pose)
+
+# Load kitchen environment
+kitchen_pose = SE3(rotation=np.identity(3), translation=np.array([0, 0, 0]))
+urdf.loadModel(robot, 0, "kitchen_area", "anchor", kitchen_urdf, kitchen_srdf, kitchen_pose)
+
+model = robot.model()
+
+robot.setJointBounds("pr2/root_joint", [-5, -2, -5.2, -2.7])
+robot.setJointBounds("box/root_joint", [-5.1, -2, -5.2, -2.7, 0, 1.5])
+
+# Create problem
+problem = Problem(robot)
+
+# Generate initial and goal configuration.
+rankInConfiguration = dict()
+current_rank = 0
+for joint_id in range(1, model.njoints):
+    joint_name = model.names[joint_id]
+    joint = model.joints[joint_id]
+    rankInConfiguration[joint_name[0:]] = current_rank
+    current_rank += joint.nq
+
+
+q_init = robot.currentConfiguration()
+rank = rankInConfiguration["pr2/l_gripper_l_finger_joint"]
+q_init[rank] = 0.5
+rank = rankInConfiguration["pr2/l_gripper_r_finger_joint"]
+q_init[rank] = 0.5
+q_init[0:2] = [-3.2, -4]
+rank = rankInConfiguration["pr2/torso_lift_joint"]
+q_init[rank] = 0.2
+rank = rankInConfiguration["box/root_joint"]
+q_init[rank : rank + 3] = [-2.5, -4, 0.746]
+q_init[rank + 3 : rank + 7] = [0, -sqrt(2) / 2, 0, sqrt(2) / 2]
+
+q_goal = q_init[::]
+q_goal[0:2] = [-3.2, -4]
+rank = rankInConfiguration["box/root_joint"]
+q_goal[rank : rank + 3] = [-2.5, -4.5, 0.746]
+
+# Create constraints
+ll = LockedJoint.create(robot.asPinDevice(), "pr2/l_gripper_l_finger_joint", np.array([0.5]))
+lr = LockedJoint.create(robot.asPinDevice(), "pr2/l_gripper_r_finger_joint", np.array([0.5]))
+
+# Create the constraint graph
+grippers = ["pr2/l_gripper"]
+objects = ["box"]
+handlesPerObject = [["box/handle2"]]
+contactSurfacesPerObject = [["box/box_surface"]]
+envContactSurfaces = ["kitchen_area/pancake_table_table_top"]
+rules = [Rule([".*"], [".*"], True)]
+
+cg = Graph("graph", robot, problem)
+cg.maxIterations(100)
+cg.errorThreshold(0.0001)
+factory = ConstraintGraphFactory(cg)
+
+factory.setGrippers(grippers)
+factory.environmentContacts(envContactSurfaces)
+factory.setObjects(objects, handlesPerObject, contactSurfacesPerObject)
+factory.setRules(rules)
+factory.generate()
+
+cg.addNumericalConstraintsToGraph([ll, lr])
+
+cg.initialize()
+
+problem.initConfig(q_init)
+problem.addGoalConfig(q_goal)
+
+print("Script completed!")
+
+

--- a/tests/graph_factory2.py
+++ b/tests/graph_factory2.py
@@ -12,7 +12,7 @@ from pyhpp.constraints import (
 )
 from pinocchio import SE3, Quaternion
 
-#based on /hpp_benchmark/2025/04-01/ur3-spheres/script.py
+# based on /hpp_benchmark/2025/04-01/ur3-spheres/script.py
 
 # Robot and environment file paths
 ur3_urdf = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
@@ -140,8 +140,11 @@ for i in range(nSphere):
         cts,
     )
     constraints[placementName + "/hold"] = ll
-    cg.registerConstraints(constraints[placementName], constraints[placementName + "/complement"],
-                         constraints[placementName + "/hold"])
+    cg.registerConstraints(
+        constraints[placementName],
+        constraints[placementName + "/complement"],
+        constraints[placementName + "/hold"],
+    )
 
     preplacementName = "preplace_sphere{0}".format(i)
     Id = SE3.Identity()

--- a/tests/graph_factory2.py
+++ b/tests/graph_factory2.py
@@ -12,6 +12,8 @@ from pyhpp.constraints import (
 )
 from pinocchio import SE3, Quaternion
 
+#based on /hpp_benchmark/2025/04-01/ur3-spheres/script.py
+
 # Robot and environment file paths
 ur3_urdf = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
 ur3_srdf = "package://example-robot-data/robots/ur_description/srdf/ur3_gripper.srdf"
@@ -71,6 +73,9 @@ model = robot.model()
 robot.setJointBounds("ur3/shoulder_pan_joint", [-pi, 4])
 robot.setJointBounds("ur3/shoulder_lift_joint", [-pi, 0])
 robot.setJointBounds("ur3/elbow_joint", [-2.6, 2.6])
+
+problem = Problem(robot)
+cg = Graph("graph", robot, problem)
 
 constraints = dict()
 
@@ -134,6 +139,9 @@ for i in range(nSphere):
         np.array([0, 0, 0.02, 0, 0, 0, 1]),
         cts,
     )
+    constraints[placementName + "/hold"] = ll
+    cg.registerConstraints(constraints[placementName], constraints[placementName + "/complement"],
+                         constraints[placementName + "/hold"])
 
     preplacementName = "preplace_sphere{0}".format(i)
     Id = SE3.Identity()
@@ -202,13 +210,11 @@ q_goal = [
     1,
 ]
 
-problem = Problem(robot)
 
 grippers = ["ur3/gripper"]
 handlesPerObject = [["sphere{0}/handle".format(i)] for i in range(nSphere)]
 contactsPerObject = [[] for i in range(nSphere)]
 
-cg = Graph("graph", robot, problem)
 cg.maxIterations(100)
 cg.errorThreshold(0.0001)
 factory = ConstraintGraphFactory(cg, constraints)

--- a/tests/graph_factory2.py
+++ b/tests/graph_factory2.py
@@ -12,7 +12,7 @@ from pyhpp.constraints import (
 )
 from pinocchio import SE3, Quaternion
 
-# based on /hpp_benchmark/2025/04-01/ur3-spheres/script.py
+#based on /hpp_benchmark/2025/04-01/ur3-spheres/script.py
 
 # Robot and environment file paths
 ur3_urdf = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
@@ -140,11 +140,8 @@ for i in range(nSphere):
         cts,
     )
     constraints[placementName + "/hold"] = ll
-    cg.registerConstraints(
-        constraints[placementName],
-        constraints[placementName + "/complement"],
-        constraints[placementName + "/hold"],
-    )
+    cg.registerConstraints(constraints[placementName], constraints[placementName + "/complement"],
+                         constraints[placementName + "/hold"])
 
     preplacementName = "preplace_sphere{0}".format(i)
     Id = SE3.Identity()

--- a/tests/graph_factory2.py
+++ b/tests/graph_factory2.py
@@ -1,0 +1,148 @@
+
+from math import sqrt, pi
+import numpy as np
+
+from pyhpp.manipulation.constraint_graph_factory import Rule, ConstraintGraphFactory
+from pyhpp.manipulation import Device, urdf, Graph, Problem
+from pyhpp.constraints import (RelativeTransformation,
+    Transformation,
+    ComparisonTypes,
+    ComparisonType,
+    BySubstitution,
+    Implicit,
+    LockedJoint)
+from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
+
+# Robot and environment file paths
+ur3_urdf = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
+ur3_srdf = "package://example-robot-data/robots/ur_description/srdf/ur3_gripper.srdf"
+sphere_urdf = "package://hpp_environments/urdf/construction_set/sphere.urdf"
+sphere_srdf = "package://hpp_environments/srdf/construction_set/sphere.srdf"
+ground_urdf = "package://hpp_environments/urdf/construction_set/ground.urdf"
+ground_srdf = "package://hpp_environments/srdf/construction_set/ground.srdf"
+
+robot = Device("ur3-spheres")
+
+# Load UR3 robot
+ur3_pose = SE3(rotation=np.identity(3), translation=np.array([0, 0, 0]))
+urdf.loadModel(robot, 0, "ur3", "anchor", ur3_urdf, ur3_srdf, ur3_pose)
+
+# Load sphere to be manipulated
+objects = list ()
+nSphere = 2
+sphere_pose = SE3(rotation=np.identity(3), translation=np.array([-2.5, -4, 0.746]))
+for i in range (nSphere):
+  urdf.loadModel(robot, 0, "sphere{0}".format (i), "freeflyer", sphere_urdf, sphere_srdf, sphere_pose)
+  robot.setJointBounds ('sphere{0}/root_joint'.format (i),
+                        [-1.,1.,-1.,1.,-.1,1.,-1.0001, 1.0001,-1.0001, 1.0001,
+                         -1.0001, 1.0001,-1.0001, 1.0001,])
+  objects.append ('sphere{0}'.format (i))
+
+# Load kitchen environment
+kitchen_pose = SE3(rotation=np.identity(3), translation=np.array([0, 0, 0]))
+urdf.loadModel(robot, 0, "kitchen_area", "anchor", ground_urdf, ground_srdf, kitchen_pose)
+
+model = robot.model()
+robot.setJointBounds ('ur3/shoulder_pan_joint', [-pi, 4])
+robot.setJointBounds ('ur3/shoulder_lift_joint', [-pi, 0])
+robot.setJointBounds ('ur3/elbow_joint', [-2.6, 2.6])
+
+constraints = dict()
+
+for i in range (nSphere):
+  o = objects[i]
+  h = robot.handles()[o + '/handle']
+  h.mask = [True,True,True,False,True,True]
+  # placement constraint
+  placementName = "place_sphere{0}".format (i)
+  Id = SE3.Identity() 
+  q = Quaternion(0, 0, 0, 1) 
+  ballPlacement = SE3(q, np.array([0, 0, 0.02]))
+  joint = robot.model().getJointId("sphere{0}/root_joint".format (i))
+  pc = Transformation.create(placementName, robot.asPinDevice(), 
+                             joint,  
+                             ballPlacement, Id, 
+                             [True, True, False, False, False, True])
+  cts = ComparisonTypes()
+  cts[:] = (
+      ComparisonType.EqualToZero,
+      ComparisonType.EqualToZero,
+      ComparisonType.EqualToZero,
+      
+  )
+  implicit_mask = [True, True, True]
+  implicitPlacementConstraint = Implicit.create(pc, cts, implicit_mask)
+  constraints[placementName] = implicitPlacementConstraint
+  # placement complement constraint
+  pc = Transformation.create(placementName + '/complement', robot.asPinDevice(), 
+                             joint,  
+                             ballPlacement, Id, 
+                             [False, False, True, True, True, False])
+  cts[:] = (
+      ComparisonType.Equality,
+      ComparisonType.Equality,
+      ComparisonType.Equality,
+  )
+  implicit_mask = [True, True, True]
+  implicitPlacementComplementConstraint = Implicit.create(pc, cts, implicit_mask)
+  constraints[placementName + '/complement'] = implicitPlacementComplementConstraint
+
+  # combination of placement and complement
+  cts[:] = (
+      ComparisonType.Equality,
+      ComparisonType.Equality,
+      ComparisonType.EqualToZero,
+      ComparisonType.EqualToZero,
+      ComparisonType.EqualToZero,
+      ComparisonType.Equality
+  )
+  ll = LockedJoint.createWithComp(robot.asPinDevice(), "sphere{0}/root_joint".format (i), np.array([0, 0, 0.02, 0, 0, 0, 1]), cts)
+
+  preplacementName = "preplace_sphere{0}".format (i)
+  Id = SE3.Identity() 
+  q = Quaternion(0, 0, 0, 1) 
+  ballPrePlacement = SE3(q, np.array([0, 0, 0.1]))
+  joint = robot.model().getJointId("sphere{0}/root_joint".format (i))
+  pc = Transformation.create(preplacementName, robot.asPinDevice(), 
+                             joint,  
+                             ballPrePlacement, Id, 
+                             [False, False, True, True, True, False])
+  cts[:] = (
+      ComparisonType.EqualToZero,
+      ComparisonType.EqualToZero,
+      ComparisonType.EqualToZero,
+  )
+  implicit_mask = [True, True, True]
+  implicitPrePlacementConstraint = Implicit.create(pc, cts, implicit_mask)
+  constraints[preplacementName] = implicitPrePlacementConstraint
+
+q_init = [pi/6, -pi/2, pi/2, 0, 0, 0,
+          0.2, 0, 0.02, 0, 0, 0, 1,
+          0.3, 0, 0.02, 0, 0, 0, 1,]
+q_goal = [pi/6, -pi/2, pi/2, 0, 0, 0,
+          0.3, 0, 0.02, 0, 0, 0, 1,
+          0.2, 0, 0.02, 0, 0, 0, 1,]
+
+problem = Problem(robot)
+
+grippers = ["ur3/gripper"]
+handlesPerObject  = [['sphere{0}/handle'.format (i)] for i in range (nSphere)]
+contactsPerObject = [[] for i in range(nSphere)]
+
+cg = Graph("graph", robot, problem)
+cg.maxIterations(100)
+cg.errorThreshold(0.0001)
+factory = ConstraintGraphFactory(cg, constraints)
+
+factory.setGrippers(grippers)
+factory.setObjects(objects, handlesPerObject, contactsPerObject)
+factory.generate()
+
+cg.initialize()
+#cg.display("./temp.dot")
+# problem.initConfig(q_init)
+# problem.addGoalConfig(q_goal)
+
+print("Script completed!")
+
+

--- a/tests/graph_factory2.py
+++ b/tests/graph_factory2.py
@@ -1,17 +1,16 @@
-
-from math import sqrt, pi
+from math import pi
 import numpy as np
 
-from pyhpp.manipulation.constraint_graph_factory import Rule, ConstraintGraphFactory
+from pyhpp.manipulation.constraint_graph_factory import ConstraintGraphFactory
 from pyhpp.manipulation import Device, urdf, Graph, Problem
-from pyhpp.constraints import (RelativeTransformation,
+from pyhpp.constraints import (
     Transformation,
     ComparisonTypes,
     ComparisonType,
-    BySubstitution,
     Implicit,
-    LockedJoint)
-from pinocchio import SE3, StdVec_Bool as Mask, Quaternion
+    LockedJoint,
+)
+from pinocchio import SE3, Quaternion
 
 # Robot and environment file paths
 ur3_urdf = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
@@ -28,105 +27,185 @@ ur3_pose = SE3(rotation=np.identity(3), translation=np.array([0, 0, 0]))
 urdf.loadModel(robot, 0, "ur3", "anchor", ur3_urdf, ur3_srdf, ur3_pose)
 
 # Load sphere to be manipulated
-objects = list ()
+objects = list()
 nSphere = 2
 sphere_pose = SE3(rotation=np.identity(3), translation=np.array([-2.5, -4, 0.746]))
-for i in range (nSphere):
-  urdf.loadModel(robot, 0, "sphere{0}".format (i), "freeflyer", sphere_urdf, sphere_srdf, sphere_pose)
-  robot.setJointBounds ('sphere{0}/root_joint'.format (i),
-                        [-1.,1.,-1.,1.,-.1,1.,-1.0001, 1.0001,-1.0001, 1.0001,
-                         -1.0001, 1.0001,-1.0001, 1.0001,])
-  objects.append ('sphere{0}'.format (i))
+for i in range(nSphere):
+    urdf.loadModel(
+        robot,
+        0,
+        "sphere{0}".format(i),
+        "freeflyer",
+        sphere_urdf,
+        sphere_srdf,
+        sphere_pose,
+    )
+    robot.setJointBounds(
+        "sphere{0}/root_joint".format(i),
+        [
+            -1.0,
+            1.0,
+            -1.0,
+            1.0,
+            -0.1,
+            1.0,
+            -1.0001,
+            1.0001,
+            -1.0001,
+            1.0001,
+            -1.0001,
+            1.0001,
+            -1.0001,
+            1.0001,
+        ],
+    )
+    objects.append("sphere{0}".format(i))
 
 # Load kitchen environment
 kitchen_pose = SE3(rotation=np.identity(3), translation=np.array([0, 0, 0]))
-urdf.loadModel(robot, 0, "kitchen_area", "anchor", ground_urdf, ground_srdf, kitchen_pose)
+urdf.loadModel(
+    robot, 0, "kitchen_area", "anchor", ground_urdf, ground_srdf, kitchen_pose
+)
 
 model = robot.model()
-robot.setJointBounds ('ur3/shoulder_pan_joint', [-pi, 4])
-robot.setJointBounds ('ur3/shoulder_lift_joint', [-pi, 0])
-robot.setJointBounds ('ur3/elbow_joint', [-2.6, 2.6])
+robot.setJointBounds("ur3/shoulder_pan_joint", [-pi, 4])
+robot.setJointBounds("ur3/shoulder_lift_joint", [-pi, 0])
+robot.setJointBounds("ur3/elbow_joint", [-2.6, 2.6])
 
 constraints = dict()
 
-for i in range (nSphere):
-  o = objects[i]
-  h = robot.handles()[o + '/handle']
-  h.mask = [True,True,True,False,True,True]
-  # placement constraint
-  placementName = "place_sphere{0}".format (i)
-  Id = SE3.Identity() 
-  q = Quaternion(0, 0, 0, 1) 
-  ballPlacement = SE3(q, np.array([0, 0, 0.02]))
-  joint = robot.model().getJointId("sphere{0}/root_joint".format (i))
-  pc = Transformation.create(placementName, robot.asPinDevice(), 
-                             joint,  
-                             ballPlacement, Id, 
-                             [True, True, False, False, False, True])
-  cts = ComparisonTypes()
-  cts[:] = (
-      ComparisonType.EqualToZero,
-      ComparisonType.EqualToZero,
-      ComparisonType.EqualToZero,
-      
-  )
-  implicit_mask = [True, True, True]
-  implicitPlacementConstraint = Implicit.create(pc, cts, implicit_mask)
-  constraints[placementName] = implicitPlacementConstraint
-  # placement complement constraint
-  pc = Transformation.create(placementName + '/complement', robot.asPinDevice(), 
-                             joint,  
-                             ballPlacement, Id, 
-                             [False, False, True, True, True, False])
-  cts[:] = (
-      ComparisonType.Equality,
-      ComparisonType.Equality,
-      ComparisonType.Equality,
-  )
-  implicit_mask = [True, True, True]
-  implicitPlacementComplementConstraint = Implicit.create(pc, cts, implicit_mask)
-  constraints[placementName + '/complement'] = implicitPlacementComplementConstraint
+for i in range(nSphere):
+    o = objects[i]
+    h = robot.handles()[o + "/handle"]
+    h.mask = [True, True, True, False, True, True]
+    # placement constraint
+    placementName = "place_sphere{0}".format(i)
+    Id = SE3.Identity()
+    q = Quaternion(0, 0, 0, 1)
+    ballPlacement = SE3(q, np.array([0, 0, 0.02]))
+    joint = robot.model().getJointId("sphere{0}/root_joint".format(i))
+    pc = Transformation.create(
+        placementName,
+        robot.asPinDevice(),
+        joint,
+        ballPlacement,
+        Id,
+        [True, True, False, False, False, True],
+    )
+    cts = ComparisonTypes()
+    cts[:] = (
+        ComparisonType.EqualToZero,
+        ComparisonType.EqualToZero,
+        ComparisonType.EqualToZero,
+    )
+    implicit_mask = [True, True, True]
+    implicitPlacementConstraint = Implicit.create(pc, cts, implicit_mask)
+    constraints[placementName] = implicitPlacementConstraint
+    # placement complement constraint
+    pc = Transformation.create(
+        placementName + "/complement",
+        robot.asPinDevice(),
+        joint,
+        ballPlacement,
+        Id,
+        [False, False, True, True, True, False],
+    )
+    cts[:] = (
+        ComparisonType.Equality,
+        ComparisonType.Equality,
+        ComparisonType.Equality,
+    )
+    implicit_mask = [True, True, True]
+    implicitPlacementComplementConstraint = Implicit.create(pc, cts, implicit_mask)
+    constraints[placementName + "/complement"] = implicitPlacementComplementConstraint
 
-  # combination of placement and complement
-  cts[:] = (
-      ComparisonType.Equality,
-      ComparisonType.Equality,
-      ComparisonType.EqualToZero,
-      ComparisonType.EqualToZero,
-      ComparisonType.EqualToZero,
-      ComparisonType.Equality
-  )
-  ll = LockedJoint.createWithComp(robot.asPinDevice(), "sphere{0}/root_joint".format (i), np.array([0, 0, 0.02, 0, 0, 0, 1]), cts)
+    # combination of placement and complement
+    cts[:] = (
+        ComparisonType.Equality,
+        ComparisonType.Equality,
+        ComparisonType.EqualToZero,
+        ComparisonType.EqualToZero,
+        ComparisonType.EqualToZero,
+        ComparisonType.Equality,
+    )
+    ll = LockedJoint.createWithComp(
+        robot.asPinDevice(),
+        "sphere{0}/root_joint".format(i),
+        np.array([0, 0, 0.02, 0, 0, 0, 1]),
+        cts,
+    )
 
-  preplacementName = "preplace_sphere{0}".format (i)
-  Id = SE3.Identity() 
-  q = Quaternion(0, 0, 0, 1) 
-  ballPrePlacement = SE3(q, np.array([0, 0, 0.1]))
-  joint = robot.model().getJointId("sphere{0}/root_joint".format (i))
-  pc = Transformation.create(preplacementName, robot.asPinDevice(), 
-                             joint,  
-                             ballPrePlacement, Id, 
-                             [False, False, True, True, True, False])
-  cts[:] = (
-      ComparisonType.EqualToZero,
-      ComparisonType.EqualToZero,
-      ComparisonType.EqualToZero,
-  )
-  implicit_mask = [True, True, True]
-  implicitPrePlacementConstraint = Implicit.create(pc, cts, implicit_mask)
-  constraints[preplacementName] = implicitPrePlacementConstraint
+    preplacementName = "preplace_sphere{0}".format(i)
+    Id = SE3.Identity()
+    q = Quaternion(0, 0, 0, 1)
+    ballPrePlacement = SE3(q, np.array([0, 0, 0.1]))
+    joint = robot.model().getJointId("sphere{0}/root_joint".format(i))
+    pc = Transformation.create(
+        preplacementName,
+        robot.asPinDevice(),
+        joint,
+        ballPrePlacement,
+        Id,
+        [False, False, True, True, True, False],
+    )
+    cts[:] = (
+        ComparisonType.EqualToZero,
+        ComparisonType.EqualToZero,
+        ComparisonType.EqualToZero,
+    )
+    implicit_mask = [True, True, True]
+    implicitPrePlacementConstraint = Implicit.create(pc, cts, implicit_mask)
+    constraints[preplacementName] = implicitPrePlacementConstraint
 
-q_init = [pi/6, -pi/2, pi/2, 0, 0, 0,
-          0.2, 0, 0.02, 0, 0, 0, 1,
-          0.3, 0, 0.02, 0, 0, 0, 1,]
-q_goal = [pi/6, -pi/2, pi/2, 0, 0, 0,
-          0.3, 0, 0.02, 0, 0, 0, 1,
-          0.2, 0, 0.02, 0, 0, 0, 1,]
+q_init = [
+    pi / 6,
+    -pi / 2,
+    pi / 2,
+    0,
+    0,
+    0,
+    0.2,
+    0,
+    0.02,
+    0,
+    0,
+    0,
+    1,
+    0.3,
+    0,
+    0.02,
+    0,
+    0,
+    0,
+    1,
+]
+q_goal = [
+    pi / 6,
+    -pi / 2,
+    pi / 2,
+    0,
+    0,
+    0,
+    0.3,
+    0,
+    0.02,
+    0,
+    0,
+    0,
+    1,
+    0.2,
+    0,
+    0.02,
+    0,
+    0,
+    0,
+    1,
+]
 
 problem = Problem(robot)
 
 grippers = ["ur3/gripper"]
-handlesPerObject  = [['sphere{0}/handle'.format (i)] for i in range (nSphere)]
+handlesPerObject = [["sphere{0}/handle".format(i)] for i in range(nSphere)]
 contactsPerObject = [[] for i in range(nSphere)]
 
 cg = Graph("graph", robot, problem)
@@ -139,10 +218,8 @@ factory.setObjects(objects, handlesPerObject, contactsPerObject)
 factory.generate()
 
 cg.initialize()
-#cg.display("./temp.dot")
+# cg.display("./temp.dot")
 # problem.initConfig(q_init)
 # problem.addGoalConfig(q_goal)
 
 print("Script completed!")
-
-


### PR DESCRIPTION
Add constraint graph factory logic to hpp-python. It works the same way as before but does not rely on CORBA architecture, only on new HPP python bindings. The graph factory is a python file which can be included and invoked in python script. Add 2 python tests scripts (one inspired from a tutorial file, the other from a benchmark) that uses the factory features.