### PR TITLE
Several additions among which access to the visual model of pinocchio

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,8 +143,7 @@ add_python_library(
   pyhpp/core/path_optimization/spline-gradient-based-abstract.cc
   pyhpp/core/path_optimization/bindings.cc
   LINK_LIBRARIES
-  hpp-core::hpp-core
-  hpp-core::hpp-core-gpl)
+  hpp-core::hpp-core)
 
 add_python_library(
   pyhpp/corbaserver FILES pyhpp/corbaserver/bindings.cc

--- a/src/pyhpp/core/bindings.cc
+++ b/src/pyhpp/core/bindings.cc
@@ -29,6 +29,7 @@
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/python.hpp>
+#include <hpp/util/debug.hh>
 #include <hpp/core/fwd.hh>
 #include <pyhpp/core/fwd.hh>
 #include <pyhpp/stl-pair.hh>
@@ -68,4 +69,8 @@ BOOST_PYTHON_MODULE(bindings) {
   boost::python::import("pyhpp.core.path_optimization");
 
   boost::python::import("pyhpp.core.problem_target");
+
+  // Bind method that sets verbosity level
+  boost::python::def("setVerbosityLevel", &::hpp::debug::setVerbosityLevel);
+  boost::python::def("getVerbosityLevel", &::hpp::debug::getVerbosityLevel);
 }

--- a/src/pyhpp/core/distance.cc
+++ b/src/pyhpp/core/distance.cc
@@ -45,10 +45,12 @@ struct DistanceWrapper {
     return dist.clone();
   }
   static value_type compute(WeighedDistance* dist, ConfigurationIn_t q1,
-                            ConfigurationIn_t q2) {
+			    ConfigurationIn_t q2) {
     return dist->compute(q1, q2);
   }
-  static vector_t getWeights(WeighedDistance* dist) { return dist->weights(); }
+  static vector_t getWeights(WeighedDistance* dist) {
+    return dist->weights();
+  }
   static void setWeights(WeighedDistance* dist, const vector_t& weights) {
     return dist->weights(weights);
   }
@@ -57,13 +59,14 @@ struct DistanceWrapper {
 void exposeDistance() {
   class_<Distance, DistancePtr_t, boost::noncopyable>("Distance", no_init)
       .def("compute", &DistanceWrapper::compute);
-  class_<WeighedDistance, bases<Distance>, WeighedDistancePtr_t,
-         boost::noncopyable>("WeighedDistance", no_init)
+  class_<WeighedDistance, bases<Distance>, WeighedDistancePtr_t, boost::noncopyable>(
+      "WeighedDistance", no_init)
       .def("create", &WeighedDistance::create)
       .staticmethod("create")
       .def("asDistancePtr_t", &DistanceWrapper::AsDistancePtr_t)
       .def("getWeights", &DistanceWrapper::getWeights)
-      .def("setWeights", &DistanceWrapper::setWeights);
+      .def("setWeights", &DistanceWrapper::setWeights)
+  ;
 }
 }  // namespace core
 }  // namespace pyhpp

--- a/src/pyhpp/core/path-validation.cc
+++ b/src/pyhpp/core/path-validation.cc
@@ -79,11 +79,11 @@ struct PVWrapper {
 };
 
 void exposePathValidation() {
-  class_<PathValidation, PathValidationPtr_t, boost::noncopyable>(
-      "PathValidation", no_init)
-      .def("validate", &PVWrapper::validate)
-      .def("validate", &PVWrapper::py_validate)
-      .def("validateConfiguration", &PVWrapper::validateConfiguration);
+    class_<PathValidation, PathValidationPtr_t, boost::noncopyable>(
+        "PathValidation", no_init)
+        .def("validate", &PVWrapper::validate)
+        .def("validate", &PVWrapper::py_validate)
+        .def("validateConfiguration", &PVWrapper::validateConfiguration);
 
   class_<pathValidation::Discretized, bases<PathValidation>,
          hpp::core::pathValidation::DiscretizedPtr_t, boost::noncopyable>(

--- a/src/pyhpp/core/roadmap.cc
+++ b/src/pyhpp/core/roadmap.cc
@@ -116,7 +116,7 @@ struct RWrapper {
   static NodePtr_t initNode2(Roadmap& roadmap) { return roadmap.initNode(); }
 
   static int numberConnectedComponents(Roadmap& roadmap) {
-    return (int)roadmap.connectedComponents().size();
+    return (int) roadmap.connectedComponents().size();
   }
 
   static ConnectedComponentPtr_t getConnectedComponent(
@@ -128,9 +128,8 @@ struct RWrapper {
   }
 
   static boost::python::list connectedComponents(Roadmap& roadmap) {
-    std::vector<ConnectedComponentPtr_t> res(
-        roadmap.connectedComponents().begin(),
-        roadmap.connectedComponents().end());
+    std::vector<ConnectedComponentPtr_t> res(roadmap.connectedComponents().begin(),
+					     roadmap.connectedComponents().end());
     return to_python_list(res);
   }
   static boost::python::list nodes(Roadmap& roadmap) {

--- a/src/pyhpp/pinocchio/device.cc
+++ b/src/pyhpp/pinocchio/device.cc
@@ -128,6 +128,9 @@ void exposeDevice() {
       .def("geomModel",
            static_cast<GeomModel& (Device::*)()>(&Device::geomModel),
            return_internal_reference<>())
+      .def("visualModel",
+           static_cast<GeomModel& (Device::*)()>(&Device::visualModel),
+           return_internal_reference<>())
       .PYHPP_DEFINE_METHOD(Device, configSize)
       .PYHPP_DEFINE_METHOD(Device, numberDof)
 


### PR DESCRIPTION
This PR enables to display visual models in gepetto-gui. It was not possible formerly since hpp-pinocchio did not store visual models.

Requires https://github.com/humanoid-path-planner/hpp-pinocchio/pull/262.
