### PR TITLE
Add access to transitions and nodes from graph, visual model from manip device

### DIFF
--- a/src/pyhpp/manipulation/device.cc
+++ b/src/pyhpp/manipulation/device.cc
@@ -48,6 +48,8 @@ Model& Device::model() { return obj->model(); }
 Data& Device::data() { return obj->data(); }
 GeomData& Device::geomData() { return obj->geomData(); }
 GeomModel& Device::geomModel() { return obj->geomModel(); }
+GeomModel& Device::visualModel() { return obj->visualModel(); }
+
 size_type Device::configSize() const { return obj->configSize(); }
 size_type Device::numberDof() const { return obj->numberDof(); }
 const Configuration_t& Device::currentConfiguration() const {
@@ -229,6 +231,9 @@ void exposeDevice() {
            return_internal_reference<>())
       .def("geomModel",
            static_cast<GeomModel& (Device::*)()>(&Device::geomModel),
+           return_internal_reference<>())
+      .def("visualModel",
+           static_cast<GeomModel& (Device::*)()>(&Device::visualModel),
            return_internal_reference<>())
       .PYHPP_DEFINE_METHOD(Device, configSize)
       .PYHPP_DEFINE_METHOD(Device, numberDof)

--- a/src/pyhpp/manipulation/device.hh
+++ b/src/pyhpp/manipulation/device.hh
@@ -27,6 +27,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#ifndef PYHPP_MANIPULATION_DEVICE_HH
+#define PYHPP_MANIPULATION_DEVICE_HH
+
 #include <hpp/constraints/implicit.hh>
 #include <hpp/manipulation/device.hh>
 #include <hpp/manipulation/handle.hh>
@@ -80,6 +83,7 @@ struct Device {
   Data& data();
   GeomData& geomData();
   GeomModel& geomModel();
+  GeomModel& visualModel();
   size_type configSize() const;
   size_type numberDof() const;
   const Configuration_t& currentConfiguration() const;
@@ -97,3 +101,4 @@ struct Device {
 };  // struct Device
 }  // namespace manipulation
 }  // namespace pyhpp
+#endif  // PYHPP_MANIPULATION_DEVICE_HH

--- a/src/pyhpp/manipulation/graph.cc
+++ b/src/pyhpp/manipulation/graph.cc
@@ -288,6 +288,7 @@ PyWStatePtr_t PyWGraph::createState(const std::string& nodeName, bool waypoint,
   if (obj->stateSelector()) {
     hpp::manipulation::graph::StatePtr_t state =
         obj->stateSelector()->createState(nodeName, waypoint, priority);
+    id[nodeName] = state->id();
     return std::shared_ptr<PyWState>(new PyWState(state));
   } else {
     throw std::logic_error("Graph has no state selector.");
@@ -302,6 +303,7 @@ PyWEdgePtr_t PyWGraph::createTransition(PyWStatePtr_t nodeFrom,
   EdgePtr_t edge = nodeFrom->obj->linkTo(transitionName, nodeTo->obj, w,
                                          (State::EdgeFactory)Edge::create);
   edge->state(isInState->obj);
+  id[transitionName] = edge->id();
   return std::shared_ptr<PyWEdge>(new PyWEdge(edge));
 }
 
@@ -354,6 +356,7 @@ PyWEdgePtr_t PyWGraph::createLevelSetTransition(PyWStatePtr_t nodeFrom,
     EdgePtr_t edge = nodeFrom->obj->linkTo(
         edgeName, nodeTo->obj, w, (State::EdgeFactory)LevelSetEdge::create);
     edge->state(isInState->obj);
+    id[edgeName] = edge->id();
     return std::shared_ptr<PyWEdge>(new PyWEdge(edge));
   } catch (const std::exception& exc) {
     throw std::logic_error(exc.what());
@@ -448,11 +451,35 @@ void PyWGraph::setWaypoint(PyWEdgePtr_t waypointEdge, int index,
   }
 }
 
+PyWEdgePtr_t PyWGraph::getTransition(const std::string& edgeName) {
+  try {
+    using namespace hpp::manipulation::graph;
+    GraphComponentPtr_t component = obj->get(id[edgeName]).lock();
+    EdgePtr_t edge = std::dynamic_pointer_cast<Edge>(component);
+    return std::shared_ptr<PyWEdge>(new PyWEdge(edge));
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+PyWStatePtr_t PyWGraph::getState(const std::string& stateName) {
+  try {
+    using namespace hpp::manipulation::graph;
+    GraphComponentPtr_t component = obj->get(id[stateName]).lock();
+    StatePtr_t state = std::dynamic_pointer_cast<State>(component);
+    return std::shared_ptr<PyWState>(new PyWState(state));
+  } catch (const std::exception& exc) {
+    throw std::logic_error(exc.what());
+  }
+}
+
+
+
 // =============================================================================
 // State queries
 // =============================================================================
 
-std::string PyWGraph::getState(ConfigurationIn_t input) {
+std::string PyWGraph::getStateFromConfiguration(ConfigurationIn_t input) {
   try {
     hpp::manipulation::graph::StatePtr_t state = obj->getState(input);
     return state->name();
@@ -1069,8 +1096,11 @@ void exposeGraph() {
       .PYHPP_DEFINE_METHOD1(PyWGraph, getWeight, DOC_GETWEIGHT)
       .PYHPP_DEFINE_METHOD1(PyWGraph, setWaypoint, DOC_SETWAYPOINT)
 
+      .PYHPP_DEFINE_METHOD(PyWGraph, getState)
+      .PYHPP_DEFINE_METHOD(PyWGraph, getTransition)
+
       // State queries
-      .PYHPP_DEFINE_METHOD1(PyWGraph, getState, DOC_GETSTATE)
+      .PYHPP_DEFINE_METHOD1(PyWGraph, getStateFromConfiguration, DOC_GETSTATE)
 
       // Constraint management
       .PYHPP_DEFINE_METHOD1(PyWGraph, addNumericalConstraint,

--- a/src/pyhpp/manipulation/graph.hh
+++ b/src/pyhpp/manipulation/graph.hh
@@ -27,6 +27,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#ifndef PYHPP_GRAPH_HH
+#define PYHPP_GRAPH_HH
+
 #include <hpp/manipulation/graph/graph.hh>
 #include <pyhpp/manipulation/fwd.hh>
 
@@ -74,6 +77,8 @@ struct PyWGraph {
   typedef hpp::constraints::ImplicitPtr_t ImplicitPtr_t;
   typedef hpp::constraints::NumericalConstraints_t NumericalConstraints_t;
 
+  std::map <std::string, std::size_t> id;
+
   // Member variables
   GraphPtr_t obj;
   PyWDevicePtr_t robot;
@@ -119,8 +124,11 @@ struct PyWGraph {
                    PyWStatePtr_t state);
   void addNumericalConstraintsToGraph(
       const boost::python::list& py_constraints);
+  PyWEdgePtr_t getTransition(const std::string& edgeName);
+  PyWStatePtr_t getState(const std::string& stateName);
+
   // State queries
-  std::string getState(ConfigurationIn_t input);
+  std::string getStateFromConfiguration(ConfigurationIn_t input);
 
   // Constraint management
   void addNumericalConstraint(PyWStatePtr_t node,
@@ -215,3 +223,4 @@ struct PyWGraph {
 
 }  // namespace manipulation
 }  // namespace pyhpp
+#endif  // PYHPP_GRAPH_HH

--- a/tests/benchmarks/ur3-spheres.py
+++ b/tests/benchmarks/ur3-spheres.py
@@ -2,9 +2,8 @@ from math import pi
 import numpy as np
 
 from pyhpp.manipulation.constraint_graph_factory import ConstraintGraphFactory
-from pyhpp.manipulation import Device, urdf, Graph, Problem
-from pyhpp.core import createDichotomy, Straight
-from pyhpp.manipulation import createProgressiveProjector, GraphSteeringMethod
+from pyhpp.manipulation import Device, Graph, Problem, createProgressiveProjector, urdf
+from pyhpp.core import createDichotomy, DiffusingPlanner, Straight
 
 from pyhpp.constraints import (
     Transformation,
@@ -16,7 +15,10 @@ from pyhpp.constraints import (
 from pinocchio import SE3, Quaternion
 
 # based on /hpp_benchmark/2025/04-01/ur3-spheres/script.py
-
+from argparse import ArgumentParser
+parser = ArgumentParser()
+parser.add_argument('-N', default=20, type=int)
+args = parser.parse_args()
 # Robot and environment file paths
 ur3_urdf = "package://example-robot-data/robots/ur_description/urdf/ur3_gripper.urdf"
 ur3_srdf = "package://example-robot-data/robots/ur_description/srdf/ur3_gripper.srdf"
@@ -98,7 +100,7 @@ for i in range(nSphere):
         joint,
         ballPlacement,
         Id,
-        [True, True, False, False, False, True],
+        [False, False, True, True, True, False],
     )
     cts = ComparisonTypes()
     cts[:] = (
@@ -116,7 +118,7 @@ for i in range(nSphere):
         joint,
         ballPlacement,
         Id,
-        [False, False, True, True, True, False],
+        [True, True, False, False, False, True],
     )
     cts[:] = (
         ComparisonType.Equality,
@@ -228,27 +230,51 @@ factory.setGrippers(grippers)
 factory.setObjects(objects, handlesPerObject, contactsPerObject)
 factory.generate()
 
-problem.initConfig(np.array(q_init))
-problem.addGoalConfig(np.array(q_goal))
+for i in range(nSphere):
+  e = cg.getTransition('ur3/gripper > sphere{}/handle | f_23'.format(i))
+  cg.addNumericalConstraintsToTransition(e, [constraints["place_sphere{}/complement".format(i)]])
+  e = cg.getTransition('ur3/gripper < sphere{}/handle | 0-{}_32'.format(i,i))
+  cg.addNumericalConstraintsToTransition(e, [constraints["place_sphere{}/complement".format(i)]])
 
-# for i in range(nSphere):
-#   e = 'ur3/gripper > sphere{}/handle | f_23'.format(i)
-#   cg.addTransitionConstraints(e, constraints["place_sphere{}/complement".format(i)])
-#   e = 'ur3/gripper < sphere{}/handle | 0-{}_32'.format(i,i)
-#   cg.addTransitionConstraints(e, constraints["place_sphere{}/complement".format(i)])
-
-
-steeringMethod = Straight(problem)
-graphSteeringMethod = GraphSteeringMethod(steeringMethod)
-problem.steeringMethod(graphSteeringMethod)
+problem.steeringMethod = Straight(problem)
 problem.pathValidation = createDichotomy(robot.asPinDevice(), 0)
 problem.pathProjector = createProgressiveProjector(
-    problem.distance(), problem.steeringMethod(), 0.01
+    problem.distance(), problem.steeringMethod, 0.01
 )
 
 cg.initialize()
+problem.initConfig(np.array(q_init))
+problem.addGoalConfig(np.array(q_goal))
+problem.constraintGraph(cg)
+diffusingPlanner = DiffusingPlanner(problem)
+diffusingPlanner.maxIterations(100000)
 
-
-# cg.display("./temp.dot")
-
-print("Script completed!")
+# Run benchmark
+#
+import datetime as dt
+totalTime = dt.timedelta (0)
+totalNumberNodes = 0
+success = 0
+for i in range (args.N):
+  try:
+    t1 = dt.datetime.now ()
+    diffusingPlanner.solve ()
+    t2 = dt.datetime.now ()
+  except Exception as e:
+    print (f"Failed to plan path: {e}")
+    break;
+  else:
+    success += 1
+    totalTime += t2 - t1
+    print (t2-t1)
+    n = len(diffusingPlanner.roadmap().nodes())
+    totalNumberNodes += n
+    print ("Number nodes: " + str(n))
+if args.N != 0:
+  print ("#" * 20)
+  print (f"Number of rounds: {args.N}")
+  print (f"Number of successes: {success}")
+  print (f"Success rate: {success/ args.N * 100}%")
+  if success > 0:
+    print (f"Average time per success: {totalTime.total_seconds()/success}")
+    print (f"Average number nodes per success: {totalNumberNodes/success}")


### PR DESCRIPTION
Now constraints objects are stored in the hpp-python graph wrapper when they are created, and can be accessed trhough python later.
Add access to the visual model through manip device to use with the new viewer.
Also add current state of a benchmark using only hpp python bindings, which fails for now