### PR TITLE
manipulation: add TransitionPlanner::planPathSingle to work around eigenpy (1,N) Ref<MatrixXd> corruption

### DIFF
--- a/src/pyhpp/manipulation/path-planner.cc
+++ b/src/pyhpp/manipulation/path-planner.cc
@@ -118,6 +118,29 @@ PathVectorPtr_t TransitionPlanner::planPath(ConfigurationIn_t qInit,
   return trObj()->planPath(qInit, qGoals, resetRoadmap);
 }
 
+PathVectorPtr_t TransitionPlanner::planPathSingle(ConfigurationIn_t qInit,
+                                                  ConfigurationIn_t qGoal,
+                                                  bool resetRoadmap) {
+  const size_type n = obj->problem()->robot()->configSize();
+  if (qInit.rows() != n) {
+    std::ostringstream os;
+    os << "qInit = " << hpp::pinocchio::displayConfig(qInit)
+       << "should be of size " << n << ".";
+    throw std::logic_error(os.str().c_str());
+  }
+  if (qGoal.rows() != n) {
+    std::ostringstream os;
+    os << "qGoal = " << hpp::pinocchio::displayConfig(qGoal)
+       << "should be of size " << n << ".";
+    throw std::logic_error(os.str().c_str());
+  }
+  // Build a C++-owned (1 x n) MatrixXd to avoid the eigenpy (1,N) conversion
+  // issue where Ref<const MatrixXd> receives garbage values for rows()>0 index.
+  hpp::constraints::matrix_t goals(1, n);
+  goals.row(0) = qGoal;
+  return trObj()->planPath(qInit, goals, resetRoadmap);
+}
+
 tuple TransitionPlanner::directPath(ConfigurationIn_t q1, ConfigurationIn_t q2,
                                     bool validate) {
   if (q1.rows() != obj->problem()->robot()->configSize()) {
@@ -255,6 +278,8 @@ void exposePathPlanners() {
       .def("innerProblem", &TransitionPlanner::innerProblem,
            DocClassMethod(innerProblem))
       .def("planPath", &TransitionPlanner::planPath, DocClassMethod(planPath))
+      .def("planPathSingle", &TransitionPlanner::planPathSingle,
+           DocClassMethod(planPath))
       .def("directPath", &TransitionPlanner::directPath)
       .def("validateConfiguration", &TransitionPlanner::validateConfiguration)
       .def("optimizePath", &TransitionPlanner::optimizePath,

--- a/src/pyhpp/manipulation/path-planner.hh
+++ b/src/pyhpp/manipulation/path-planner.hh
@@ -56,6 +56,8 @@ struct TransitionPlanner : public pyhpp::core::PathPlanner {
   pyhpp::core::Problem innerProblem() const;
   PathVectorPtr_t planPath(ConfigurationIn_t qInit, matrixIn_t qGoals,
                            bool resetRoadmap);
+  PathVectorPtr_t planPathSingle(ConfigurationIn_t qInit,
+                                 ConfigurationIn_t qGoal, bool resetRoadmap);
   tuple directPath(ConfigurationIn_t q1, ConfigurationIn_t q2, bool validate);
   tuple validateConfiguration(ConfigurationIn_t q, std::size_t id) const;
   PathVectorPtr_t optimizePath(const PathPtr_t& path);


### PR DESCRIPTION
When a (1,N) numpy array is passed as matrixIn_t (Eigen::Ref<const MatrixXd>), numpy marks it as both C- and F-contiguous (layout is irrelevant for a single row). eigenpy's is_arr_layout_compatible_with_mat_type<MatrixXd> checks only the F-contiguous flag, sees true, and creates a direct Map with NumpyMapStride = Stride<0,0>. The compile-time-zero strides override the actual numpy strides, so only element (0,0) maps correctly; all (0,c) for c > 0 read garbage memory.

planPath(qInit, qGoals, reset) is preserved unchanged and works correctly for multi-row goals matrices (rows > 1), where C- and F-contiguous flags differ and eigenpy correctly allocates a copy.

planPathSingle(qInit, qGoal, reset) is added as a safe single-goal alternative: it accepts two 1D ConfigurationIn_t (Ref<const VectorXd>, handled correctly by eigenpy's IsVectorAtCompileTime specialisation) and builds a C++-owned MatrixXd(1,n) internally before calling planPath.