### PR TITLE
manipulation: fix planPath for (1,N) numpy goals

### DIFF
--- a/src/pyhpp/manipulation/path-planner.cc
+++ b/src/pyhpp/manipulation/path-planner.cc
@@ -124,8 +124,8 @@ PathVectorPtr_t TransitionPlanner::planPath(ConfigurationIn_t qInit,
   // Multi-row matrices (rows > 1) are not affected: their C- and F-contiguous
   // flags differ, so eigenpy correctly allocates a copy.
   if (qGoals.rows() == 1) {
-    typedef Eigen::Map<const Eigen::Matrix<double, 1, Eigen::Dynamic,
-                                           Eigen::RowMajor>>
+    typedef Eigen::Map<
+        const Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor>>
         RowMap;
     const hpp::constraints::matrix_t goals =
         RowMap(qGoals.data(), 1, qGoals.cols());

--- a/src/pyhpp/manipulation/path-planner.cc
+++ b/src/pyhpp/manipulation/path-planner.cc
@@ -115,6 +115,22 @@ PathVectorPtr_t TransitionPlanner::planPath(ConfigurationIn_t qInit,
     os << "qGoals = " << qGoals << "should have at least one line.";
     throw std::logic_error(os.str().c_str());
   }
+  // Workaround for eigenpy bug: (1,N) numpy arrays have both C- and
+  // F-contiguous flags set. eigenpy's is_arr_layout_compatible_with_mat_type
+  // sees F-contiguous and creates Ref<MatrixXd> with Stride<0,0>, causing
+  // the actual numpy strides to be ignored. Only element (0,0) maps correctly;
+  // all other columns receive garbage. Re-map via the raw data pointer with an
+  // explicit RowMajor layout to recover the correct values.
+  // Multi-row matrices (rows > 1) are not affected: their C- and F-contiguous
+  // flags differ, so eigenpy correctly allocates a copy.
+  if (qGoals.rows() == 1) {
+    typedef Eigen::Map<const Eigen::Matrix<double, 1, Eigen::Dynamic,
+                                           Eigen::RowMajor>>
+        RowMap;
+    const hpp::constraints::matrix_t goals =
+        RowMap(qGoals.data(), 1, qGoals.cols());
+    return trObj()->planPath(qInit, goals, resetRoadmap);
+  }
   return trObj()->planPath(qInit, qGoals, resetRoadmap);
 }
 


### PR DESCRIPTION
I would like to propose an alternative fix to #124.

eigenpy's is_arr_layout_compatible_with_mat_type marks (1,N) numpy arrays as F-contiguous (both C- and F-contiguous flags are set for single-row arrays), then creates Ref<const MatrixXd> with Stride<0,0>. This causes the runtime numpy strides to be ignored: only element (0,0) is read correctly, all other columns receive garbage.

Fix: when qGoals.rows()==1, re-map the raw data pointer with an explicit Eigen::RowMajor layout before passing to the C++ planPath. The raw data pointer is always correct; 1-row data is contiguous; RowMajor reads it in order. Assign to a C++-owned matrix_t before the call to avoid any Ref aliasing.

Multi-row matrices (rows > 1) are unaffected because their C- and F-contiguous flags differ, so eigenpy allocates a copy correctly.