### PR TITLE
Fix combinatorial blowup in ConstraintGraphFactory._recurse() from missing negative-memoization

### DIFF
--- a/src/pyhpp/manipulation/constraint_graph_factory.py
+++ b/src/pyhpp/manipulation/constraint_graph_factory.py
@@ -249,23 +249,18 @@ class GraphFactoryAbstract(ABC):
      The first node is defined by the empty set. The graph is built recursiveley
      as follows:
 
-     if the set of grasps defining the node is not allowed (method \\link
+     For any pair \\f$(g,h)\\f$ of available grippers and available handles,
+     \\li if the resulting set of grasps is allowed (method \\link
          constraint_graph_factory.GraphFactoryAbstract.graspIsAllowed
-         graspIsAllowed \\endlink), return.
-
-     Otherwise, for any pair \\f$(g,h)\f$ of available grippers and available
-     handles,
-     \\li build a new state by adding grasp \\f$(g,h)\\f$ to the current set of
-         grasps (method
-         \\link constraint_graph_factory.GraphFactoryAbstract.makeState
-         makeState\\endlink),
-     \\li build a transition from the current state to the new state (method \\link
-         constraint_graph_factory.GraphFactoryAbstract.makeTransition
-         makeTransition \\endlink)
-     \\li build a loopTransition from the current state to itself (method \\link
-         constraint_graph_factory.GraphFactoryAbstract.makeLoopTransition
-         makeLoopTransition \\endlink)
-     \\li repeat the two above states to the new state.
+         graspIsAllowed \\endlink), build a new state (method \\link
+         constraint_graph_factory.GraphFactoryAbstract.makeState
+         makeState\\endlink) and a transition from the current state (method
+         \\link constraint_graph_factory.GraphFactoryAbstract.makeTransition
+         makeTransition \\endlink),
+     \\li regardless of whether the next set of grasps is allowed, recurse into
+         it if it has not been visited before (to support non-monotonic filter
+         rules). A rejected set of grasps is memoized so its subtree is never
+         re-explored from a different parent path.
     """
 
     def __init__(self):
@@ -283,6 +278,9 @@ class GraphFactoryAbstract(ABC):
 
         self.states = dict()
         self.transitions = set()
+        # Recursion-visited memo for all nGrasps, accepted or rejected.
+        # Separate from self.states, which only holds created State objects.
+        self._visitedGrasps = set()
         # # the handle names
         self.handles = tuple()  # strings
         # # the gripper names
@@ -507,7 +505,9 @@ class GraphFactoryAbstract(ABC):
                 nGrasps = grasps[:isg] + (ish,) + grasps[isg + 1 :]
 
                 nextIsAllowed = self.graspIsAllowed(nGrasps)
-                isNewState = not self._existState(nGrasps)
+                isNewState = nGrasps not in self._visitedGrasps
+                if isNewState:
+                    self._visitedGrasps.add(nGrasps)
                 if nextIsAllowed:
                     nnext = self._makeState(nGrasps, depth + 1)
 


### PR DESCRIPTION
## Summary
`GraphFactoryAbstract._recurse()` memoizes visited grasp combinations
via `self.states`/`_existState()`, but `self.states` is only populated
for combinations *accepted* by `graspIsAllowed`. Rejected combinations
were never marked visited, so their entire descendant subtree was
redundantly re-explored from every distinct parent path that reached
them.

Downstream, this caused a 20+ minute hang building the constraint
graph for a phase with 8 simultaneously-held grippers / 7 objects — a
case with a restrictive filter that *should* have been fast per this
module's own docstring (O(N) for such filters), but wasn't, because
rejections were the majority case and none of them were cached.

## Fix
Add a `_visitedGrasps` set, separate from `self.states` (real created
State objects, used elsewhere), populated for every `nGrasps` tuple
regardless of whether `graspIsAllowed` accepted or rejected it.

## Testing
Standalone, HPP-independent reproduction (stubs the two compiled deps
`_recurse` doesn't actually touch — `pyhpp.constraints.{Implicit,
LockedJoint}`, `numpy`; a trivial concrete subclass recording into
plain sets instead of touching real graph objects):
- Diffed the resulting `{grasps}` state-set and `{(from,to,ig)}`
  transition-set between unpatched and patched `_recurse` for N=2..8
  grippers/handles, including an adversarial non-monotonic filter
  (rejects most intermediate combinations, accepts one specific deep
  target) — states/transitions match exactly in every case; only the
  redundant recursion is eliminated.
- `_recurse` call counts drop sharply for the patched version (n=6:
  137,266 → 4,051 calls) and stay fast at n=8 (394,353 calls, matching
  the closed-form combinatorial floor Σ C(nG,k)·P(nH,k) exactly).
- Full downstream 13-phase sequential manipulation test previously
  hung indefinitely on its final, most complex phase; now completes.