### PR TITLE
Expose Progressive::timeOut() to Python

### DIFF
--- a/src/pyhpp/core/path-validation.cc
+++ b/src/pyhpp/core/path-validation.cc
@@ -133,6 +133,20 @@ struct Progressive : PathValidation {
                        tolerance) {}
 };
 
+struct ProgressiveWrapper {
+  static hpp::core::value_type getTimeOut(PathValidation* pv) {
+    return HPP_DYNAMIC_PTR_CAST(hpp::core::continuousValidation::Progressive,
+                                pv->obj)
+        ->timeOut();
+  }
+  static void setTimeOut(PathValidation* pv,
+                         const hpp::core::value_type& timeOut) {
+    HPP_DYNAMIC_PTR_CAST(hpp::core::continuousValidation::Progressive,
+                         pv->obj)
+        ->timeOut(timeOut);
+  }
+};
+
 struct Dichotomy : PathValidation {
   Dichotomy(const hpp::core::DevicePtr_t& robot,
             const hpp::core::value_type& tolerance)
@@ -184,7 +198,11 @@ void exposePathValidation() {
   class_<pathValidation::Progressive, bases<PathValidation>>(
       "Progressive", "Create a progressive continuous path validation.",
       init<const hpp::core::DevicePtr_t&, const hpp::core::value_type&>(
-          (arg("robot"), arg("tolerance"))));
+          (arg("robot"), arg("tolerance"))))
+      .def("timeOut", &pathValidation::ProgressiveWrapper::getTimeOut,
+           "Get wall-clock timeout (seconds) for path validation.")
+      .def("timeOut", &pathValidation::ProgressiveWrapper::setTimeOut,
+           "Set wall-clock timeout (seconds) for path validation.");
   class_<pathValidation::Dichotomy, bases<PathValidation>>(
       "Dichotomy", "Create a dichotomy-based continuous path validation.",
       init<const hpp::core::DevicePtr_t&, const hpp::core::value_type&>(

--- a/src/pyhpp/core/path-validation.cc
+++ b/src/pyhpp/core/path-validation.cc
@@ -141,8 +141,7 @@ struct ProgressiveWrapper {
   }
   static void setTimeOut(PathValidation* pv,
                          const hpp::core::value_type& timeOut) {
-    HPP_DYNAMIC_PTR_CAST(hpp::core::continuousValidation::Progressive,
-                         pv->obj)
+    HPP_DYNAMIC_PTR_CAST(hpp::core::continuousValidation::Progressive, pv->obj)
         ->timeOut(timeOut);
   }
 };


### PR DESCRIPTION
## Summary
`continuousValidation::Progressive` gained a configurable `timeOut()`
getter/setter in hpp-core (humanoid-path-planner/hpp-core#450), replacing
a hardcoded 15s wall-clock bound in `validateStraightPath()`. This binds
it so it's reachable from Python — without it, the new setting isn't
actually usable by any project that only talks to hpp-core through these
bindings (as opposed to linking hpp-core directly).

**Depends on hpp-core#450** — needs that PR's `Progressive::timeOut()`
C++ method to exist before this can build.

## Change
`pathValidation::Progressive`'s pybind wrapper stores the concrete
validator behind a generic `PathValidationPtr_t`. Added a
`ProgressiveWrapper` with static getter/setter functions that downcast
to `continuousValidation::ProgressivePtr_t` via `HPP_DYNAMIC_PTR_CAST`,
matching the existing `PVWrapper` pattern already used for
`validate()`/`validateConfiguration()`. Bound as an overloaded `timeOut`
method (get with no args, set with a `float` arg) on the `Progressive`
Python class.

## Testing
Built against a local hpp-core checkout with #450's changes applied;
verified from Python:
```python
from pyhpp.core import Progressive
from pyhpp.pinocchio import Device
d = Device('test')
prog = Progressive(d, 0.001)
prog.timeOut()       # -> 15.0 (default, matches prior hardcoded value)
prog.timeOut(45.0)
prog.timeOut()       # -> 45.0
```
